### PR TITLE
Disable scrolling when overlay components are open

### DIFF
--- a/src/components/Backdrop/Backdrop.tsx
+++ b/src/components/Backdrop/Backdrop.tsx
@@ -13,6 +13,7 @@ const Backdrop = forwardRef<HTMLDivElement, BackdropProps>(
         w="100%"
         h="100%"
         pos="fixed"
+        of="hidden"
         t={0}
         l={0}
         z={200}

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -1,4 +1,4 @@
-import { forwardRef } from "react";
+import { forwardRef, useEffect } from "react";
 // Components
 import Animation, { AnimationProps } from "../Animation/Animation";
 import Paper from "../Paper/Paper";
@@ -51,6 +51,14 @@ const Dialog: PrismaneWithInternal<
     const presence = usePresence(open as boolean, duration, animate);
 
     useKeyboardShortcut(["escape"], onClose, open);
+
+    useEffect(() => {
+      if (open) {
+        document.body.style.overflow = "hidden";
+      } else {
+        document.body.style.overflow = "";
+      }
+    }, [open]);
 
     return (
       <Portal>

--- a/src/components/Drawer/Drawer.tsx
+++ b/src/components/Drawer/Drawer.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, ReactNode } from "react";
+import { forwardRef, ReactNode, useEffect } from "react";
 // Components
 import Paper, { PaperProps } from "../Paper/Paper";
 import Animation, { AnimationProps } from "../Animation/Animation";
@@ -54,6 +54,14 @@ const Drawer: PrismaneWithInternal<
     const presence = usePresence(open as boolean, duration, animate);
 
     useKeyboardShortcut(["escape"], onClose, open);
+
+    useEffect(() => {
+      if (open) {
+        document.body.style.overflow = "hidden";
+      } else {
+        document.body.style.overflow = "";
+      }
+    }, [open]);
 
     return (
       <Portal>

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -1,4 +1,4 @@
-import { forwardRef } from "react";
+import { forwardRef, useEffect } from "react";
 // Components
 import Paper, { PaperProps } from "../Paper/Paper";
 import Animation, { AnimationProps } from "../Animation/Animation";
@@ -51,6 +51,14 @@ const Modal: PrismaneWithInternal<
     const presence = usePresence(open as boolean, duration, animate);
 
     useKeyboardShortcut(["escape"], onClose, open);
+
+    useEffect(() => {
+      if (open) {
+        document.body.style.overflow = "hidden";
+      } else {
+        document.body.style.overflow = "";
+      }
+    }, [open]);
 
     return (
       <Portal>


### PR DESCRIPTION
This merge fixes the issue that enabled users to scroll when an overlay component was shown (Drawer, Modal, Dialog).