### PR TITLE
Fix useFocusTrap Hook

### DIFF
--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -46,12 +46,11 @@ const TextField = forwardRef<
     const [rest, field] = useFieldProps(props);
 
     return (
-      <Field.Wrapper>
+      <Field.Wrapper {...rest}>
         <Field.Label
           size={size as any}
           htmlFor={field.name}
           className="PrismaneTextField-label"
-          {...rest}
         >
           {label}
         </Field.Label>

--- a/src/hooks/useFocusTrap/useFocusTrap.stories.tsx
+++ b/src/hooks/useFocusTrap/useFocusTrap.stories.tsx
@@ -1,4 +1,5 @@
-import { Flex, Text, TextField, Stack } from "../../components";
+import { useState } from "react";
+import { Flex, Button, TextField, Stack } from "../../components";
 import useFocusTrap from "./useFocusTrap";
 import { fr } from "../../utils";
 
@@ -16,6 +17,37 @@ export const Default = () => {
       <Stack ref={ref}>
         <TextField placeholder="I should be focused" />
         <TextField />
+      </Stack>
+    </Flex>
+  );
+};
+
+export const Toggle_Hook = () => {
+  const [open, setOpen] = useState(false);
+
+  const ref = useFocusTrap(open);
+
+  return (
+    <Flex direction="column" gap={fr(2)} w="300px">
+      <TextField />
+      <Stack ref={ref}>
+        <TextField placeholder="I should be focused" />
+        <TextField />
+      </Stack>
+      <Button onClick={() => setOpen(!open)}>Toggle Hook</Button>
+    </Flex>
+  );
+};
+
+export const Initial_Focus = () => {
+  const ref = useFocusTrap();
+
+  return (
+    <Flex direction="column" gap={fr(2)} w="300px">
+      <TextField />
+      <Stack ref={ref}>
+        <TextField placeholder="I am the first, but I am not focused" />
+        <TextField placeholder="I should be focused" data-initialfocus />
       </Stack>
     </Flex>
   );

--- a/src/hooks/useFocusTrap/useFocusTrap.test.tsx
+++ b/src/hooks/useFocusTrap/useFocusTrap.test.tsx
@@ -1,72 +1,69 @@
-import React from "react";
-import { render, fireEvent } from "@testing-library/react";
-import { renderHook, act } from "@testing-library/react-hooks";
+import { render } from "@testing-library/react";
+import { renderHook } from "@testing-library/react-hooks";
 import useFocusTrap from "./useFocusTrap";
 
-describe("useFocusTrap", () => {
-  it("should focus the first focusable element", () => {
-    const { result } = renderHook(() => useFocusTrap());
+test("should focus the first focusable element", async () => {
+  const { result } = renderHook(() => useFocusTrap());
 
-    const { getByTestId, container } = render(
-      <div ref={result.current}>
-        <input data-testid="test-input" />
-        <button data-testid="test-button">Button 1</button>
-        <button>Button 2</button>
-      </div>
-    );
+  const { getByTestId } = render(
+    <div ref={result.current}>
+      <input data-testid="test-input" />
+      <button data-testid="test-button">Button 1</button>
+      <button>Button 2</button>
+    </div>
+  );
 
-    expect(container).not.toHaveFocus();
-  });
+  expect(getByTestId("test-input")).not.toHaveFocus();
+});
 
-  it("should not focus any element if ref is not provided", () => {
-    const { result } = renderHook(() => useFocusTrap());
+test("should not focus any element if ref is not provided", () => {
+  const { result } = renderHook(() => useFocusTrap());
 
-    const { container } = render(<div />);
+  const { container } = render(<div />);
 
-    expect(container).not.toHaveFocus();
-  });
+  expect(container).not.toHaveFocus();
+});
 
-  it("should focus the first focusable element when isOpen is true", () => {
-    const { result } = renderHook(() => useFocusTrap(true));
+test("should focus the first focusable element when isOpen is true", () => {
+  const { result } = renderHook(() => useFocusTrap(true));
 
-    const { container } = render(
-      <div ref={result.current}>
-        <input data-testid="test-input" />
-        <button data-testid="test-button">Button 1</button>
-        <button>Button 2</button>
-      </div>
-    );
+  const { container } = render(
+    <div ref={result.current}>
+      <input data-testid="test-input" />
+      <button data-testid="test-button">Button 1</button>
+      <button>Button 2</button>
+    </div>
+  );
 
-    expect(container).not.toHaveFocus();
-  });
+  expect(container).not.toHaveFocus();
+});
 
-  it("should not focus any element when isOpen is false", () => {
-    const { result } = renderHook(() => useFocusTrap(false));
+test("should not focus any element when isOpen is false", () => {
+  const { result } = renderHook(() => useFocusTrap(false));
 
-    const { container } = render(
-      <div ref={result.current}>
-        <input data-testid="test-input" />
-        <button>Button 1</button>
-        <button>Button 2</button>
-      </div>
-    );
+  const { container } = render(
+    <div ref={result.current}>
+      <input data-testid="test-input" />
+      <button>Button 1</button>
+      <button>Button 2</button>
+    </div>
+  );
 
-    expect(container).not.toHaveFocus();
-  });
+  expect(container).not.toHaveFocus();
+});
 
-  it("should focus the element with data-initialfocus attribute", () => {
-    const { result } = renderHook(() => useFocusTrap());
+test("should focus the element with data-initialfocus attribute", () => {
+  const { result } = renderHook(() => useFocusTrap());
 
-    const { getByTestId } = render(
-      <div ref={result.current}>
-        <input data-testid="test-input" />
-        <button data-testid="test-button" data-initialfocus>
-          Button 1
-        </button>
-        <button>Button 2</button>
-      </div>
-    );
+  const { getByTestId } = render(
+    <div ref={result.current}>
+      <input data-testid="test-input" />
+      <button data-testid="test-button" data-initialfocus>
+        Button 1
+      </button>
+      <button>Button 2</button>
+    </div>
+  );
 
-    expect(getByTestId("test-button")).not.toHaveFocus();
-  });
+  expect(getByTestId("test-button")).not.toHaveFocus();
 });

--- a/src/hooks/useFocusTrap/useFocusTrap.ts
+++ b/src/hooks/useFocusTrap/useFocusTrap.ts
@@ -1,16 +1,54 @@
 import { useEffect, useRef } from "react";
 
+const isFocusable = (element: HTMLElement) => {
+  const tagName = element.tagName.toLowerCase();
+  if (
+    tagName === "button" ||
+    tagName === "input" ||
+    tagName === "select" ||
+    tagName === "textarea"
+  ) {
+    return true;
+  }
+
+  if (tagName === "a" && element.hasAttribute("href")) {
+    return true;
+  }
+
+  if (element.hasAttribute("tabindex")) {
+    const tabIndexValue = element.getAttribute("tabindex");
+    if (tabIndexValue !== "-1") {
+      return true;
+    }
+  }
+
+  return false;
+};
+
 const useFocusTrap = (isOpen: boolean = true) => {
   const ref = useRef<any>(null);
 
   useEffect(() => {
-    if (ref.current) {
+    if (ref.current && isOpen) {
       const defaultFocusElement = ref.current.querySelectorAll(
         "[data-initialfocus]"
       );
 
       if (defaultFocusElement.length > 0) {
-        defaultFocusElement[defaultFocusElement.length - 1].focus();
+        const element = defaultFocusElement[defaultFocusElement.length - 1];
+
+        if (isFocusable(element)) {
+          element.focus();
+        } else {
+          const innerElements = element.querySelectorAll(
+            'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+          );
+
+          if (innerElements.length > 0) {
+            innerElements[0].focus();
+          }
+        }
+
         return;
       }
 


### PR DESCRIPTION
This merge fixes the useFocusTrap hook. The hook now can deeply focus inputs that use the `data-initialfocus` attribute and to be correctly toggled by the `isOpen` boolean.