### PR TITLE
Fix Dialog Closing When Clicked Inside

### DIFF
--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -136,6 +136,9 @@ const Dialog = forwardRef<HTMLDivElement, DialogProps>(
                 "left-end": fr(6),
               })}
               z={200}
+              onClick={(e: any) => {
+                e.stopPropagation();
+              }}
               animated={animating}
               duration={duration}
               timing={timing}


### PR DESCRIPTION
This merge fixes an issue where the dialog closes when clicked inside instead of stopping the propagation of the event.