### PR TITLE
Fix Container maxSize Prop Type To Support Sizes Up To 6xl

### DIFF
--- a/src/components/Container/Container.tsx
+++ b/src/components/Container/Container.tsx
@@ -8,7 +8,14 @@ import { strip } from "../../utils";
 
 export type ContainerProps = PrismaneProps<
   {
-    maxSize?: PrismaneBreakpoints;
+    maxSize?:
+      | PrismaneBreakpoints
+      | "xl"
+      | "2xl"
+      | "3xl"
+      | "4xl"
+      | "5xl"
+      | "6xl";
   },
   FlexProps
 >;


### PR DESCRIPTION
This merge fixes a bug where the maxSize prop type of the Container component didn't have the full list of supported values and resulted in a type error when passing a valid value.