### PR TITLE
Change Button's Border Radius On Larger Sizes

### DIFF
--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -3,6 +3,7 @@ import { Pause, ArchiveBox } from "@phosphor-icons/react";
 // Components
 import Button from "./Button";
 import Flex from "../Flex/Flex";
+import Stack from "../Stack/Stack";
 // Utils
 import { fr } from "../../utils";
 
@@ -65,5 +66,27 @@ export const Full_Button = () => {
     <Flex w={fr(96)} h={fr(20)} direction="column">
       <Button full>Full Width Button</Button>
     </Flex>
+  );
+};
+
+export const Button_Sizes = () => {
+  return (
+    <Stack align="center">
+      <Button w={fr(120)} size="xs">
+        xs
+      </Button>
+      <Button w={fr(120)} size="sm">
+        sm
+      </Button>
+      <Button w={fr(120)} size="base">
+        base
+      </Button>
+      <Button w={fr(120)} size="md">
+        md
+      </Button>
+      <Button w={fr(120)} size="lg">
+        lg
+      </Button>
+    </Stack>
   );
 };

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -82,7 +82,13 @@ const Button: ButtonComponent = forwardRef(
           lg: fr(2.75),
         })}
         h="fit-content"
-        br={size}
+        br={variants(size, {
+          xs: "xs",
+          sm: "sm",
+          base: "base",
+          md: "base",
+          lg: "md",
+        })}
         op={[1, { disabled: 0.5 }]}
         bg={(theme) =>
           variants(variant, {


### PR DESCRIPTION
This merge fixes an issue where the border radius of the Button component didn't scale consistently on bigger sizes.