### PR TITLE
Add fontFamily to theme object + Ship with Poppins font preinstalled

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,8 +1,4 @@
 <style>
-  * {
-    font-family: "Poppins" !important;
-  }
-
   html {
     display: flex;
     height: 100%;

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,14 +1,6 @@
 import React from "react";
 import type { Preview } from "@storybook/react";
-import "@fontsource/poppins/100.css";
-import "@fontsource/poppins/200.css";
-import "@fontsource/poppins/300.css";
-import "@fontsource/poppins/400.css";
-import "@fontsource/poppins/500.css";
-import "@fontsource/poppins/600.css";
-import "@fontsource/poppins/700.css";
-import "@fontsource/poppins/800.css";
-import "@fontsource/poppins/900.css";
+
 // Prismane
 import PrismaneProvider from "../src/components/PrismaneProvider/PrismaneProvider";
 import Flex from "../src/components/Flex/Flex";

--- a/package.json
+++ b/package.json
@@ -71,6 +71,8 @@
     }
   },
   "dependencies": {
+    "@fontsource/poppins": "^4.5.10",
+    "@phosphor-icons/react": "^2.0.9",
     "@stitches/react": "^1.2.8"
   },
   "peerDependencies": {
@@ -78,8 +80,6 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@fontsource/poppins": "^4.5.10",
-    "@phosphor-icons/react": "^2.0.9",
     "@storybook/addon-essentials": "7.1.0",
     "@storybook/addon-interactions": "7.1.0",
     "@storybook/addon-links": "7.1.0",

--- a/src/components/PrismaneProvider/PrismaneProvider.tsx
+++ b/src/components/PrismaneProvider/PrismaneProvider.tsx
@@ -8,6 +8,16 @@ import { base } from "../../themes/base";
 import { createTheme, applyTheme } from "../../themes/theme";
 // Types
 import { PrismaneInputTheme } from "../../types";
+// Font
+import "@fontsource/poppins/100.css";
+import "@fontsource/poppins/200.css";
+import "@fontsource/poppins/300.css";
+import "@fontsource/poppins/400.css";
+import "@fontsource/poppins/500.css";
+import "@fontsource/poppins/600.css";
+import "@fontsource/poppins/700.css";
+import "@fontsource/poppins/800.css";
+import "@fontsource/poppins/900.css";
 
 export type PrismaneProviderProps = {
   children: ReactNode;

--- a/src/index.css
+++ b/src/index.css
@@ -217,9 +217,13 @@ html {
 
 body {
   margin: 0;
-  font-family: inherit;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+*[class^="Prismane"],
+*[class*=" Prismane"] {
+  font-family: var(--prismane-font-family);
 }
 
 * {

--- a/src/themes/base.ts
+++ b/src/themes/base.ts
@@ -19,6 +19,7 @@ export const base: PrismaneTheme = {
     xl: fr(3),
     "2xl": fr(3.5),
   },
+  fontFamily: "Poppins",
 };
 
 export default {

--- a/src/themes/theme.ts
+++ b/src/themes/theme.ts
@@ -66,6 +66,7 @@ export const mapTheme = (config: PrismaneTheme): PrismaneMappedTheme => {
     "--prismane-border-radius-lg": config.borderRadius.lg,
     "--prismane-border-radius-xl": config.borderRadius.xl,
     "--prismane-border-radius-2xl": config.borderRadius["2xl"],
+    "--prismane-font-family": config.fontFamily,
     mode: config.mode,
   };
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -284,6 +284,7 @@ export type PrismaneTheme = {
     xl: string;
     "2xl": string;
   };
+  fontFamily: string;
 };
 
 type DeepPartial<T> = {


### PR DESCRIPTION
This merge adds the font-family CSS rule to the theme object and includes a preinstalled Poppins font with Prismane.