### PR TITLE
Add Area Props To Grid Components

### DIFF
--- a/src/components/Grid/Grid.stories.tsx
+++ b/src/components/Grid/Grid.stories.tsx
@@ -43,3 +43,31 @@ export const Default: FC = () => {
     </Grid>
   );
 };
+
+export const Areas: FC = () => {
+  return (
+    <Grid
+      templateAreas={`"header header"
+                  "nav main"
+                  "nav footer"`}
+      templateRows={3}
+      templateColumns={2}
+      h="200px"
+      w="600px"
+      gap="4px"
+    >
+      <Grid.Item pl="8px" bg="orange" area={"header"}>
+        Header
+      </Grid.Item>
+      <Grid.Item pl="8px" bg="pink" area={"nav"}>
+        Nav
+      </Grid.Item>
+      <Grid.Item pl="8px" bg="green" area={"main"}>
+        Main
+      </Grid.Item>
+      <Grid.Item pl="8px" bg="blue" area={"footer"}>
+        Footer
+      </Grid.Item>
+    </Grid>
+  );
+};

--- a/src/components/Grid/Grid.tsx
+++ b/src/components/Grid/Grid.tsx
@@ -13,6 +13,7 @@ export { type GridItemProps };
 
 export type GridProps = PrismaneProps<
   {
+    templateAreas?: string;
     templateColumns?: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | "none";
     templateRows?: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | "none";
     flow?: "row" | "column" | "dense" | "row-dense" | "column-dense";
@@ -26,6 +27,7 @@ export type GridProps = PrismaneProps<
 const Grid = forwardRef<HTMLDivElement, GridProps>(
   (
     {
+      templateAreas,
       templateColumns,
       templateRows,
       flow,
@@ -45,6 +47,7 @@ const Grid = forwardRef<HTMLDivElement, GridProps>(
         dp="grid"
         sx={{
           gap: gap,
+          gridTemplateAreas: templateAreas,
           gridTemplateColumns:
             typeof templateColumns === "number"
               ? `repeat(${templateColumns}, minmax(0, 1fr))`

--- a/src/components/Grid/GridItem/GridItem.tsx
+++ b/src/components/Grid/GridItem/GridItem.tsx
@@ -8,6 +8,7 @@ import { strip, variants } from "../../../utils";
 
 export type GridItemProps = PrismaneProps<
   {
+    area?: string;
     columnStart?:
       | 1
       | 2
@@ -35,6 +36,7 @@ export type GridItemProps = PrismaneProps<
 const GridItem = forwardRef<HTMLDivElement, GridItemProps>(
   (
     {
+      area,
       columnStart,
       columnEnd,
       columnSpan,
@@ -55,6 +57,7 @@ const GridItem = forwardRef<HTMLDivElement, GridItemProps>(
         className={strip(`${className ? className : ""} PrismaneGridItem-root`)}
         sx={{
           gap,
+          gridArea: area,
           gridColumnStart: columnStart,
           gridColumnEnd: columnEnd,
           gridColumnSpan:


### PR DESCRIPTION
This merge introduces an `area` prop to the `Grid.Item` component and a `templateAreas` prop to the `Grid` component.