### PR TITLE
Remove onSubmit and onReset Prop Types From Form Component

### DIFF
--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -1,18 +1,10 @@
 import { forwardRef } from "react";
 // Components
 import Box, { BoxProps } from "../Box/Box";
-// Types
-import { PrismaneProps } from "../../types";
 // Utils
 import { strip, fr } from "../../utils";
 
-export type FormProps = PrismaneProps<
-  {
-    onSubmit: any;
-    onReset?: any;
-  },
-  BoxProps<"form">
->;
+export type FormProps = BoxProps<"form">;
 
 const Form = forwardRef<HTMLFormElement, FormProps>(
   ({ children, onSubmit, onReset, className, sx, ...props }, ref) => {


### PR DESCRIPTION
This merge removes the unneeded type declarations of the `onReset` and `onSubmit` props.