### PR TITLE
Add Checkbox Icon Prop

### DIFF
--- a/src/components/Checkbox/Checkbox.stories.tsx
+++ b/src/components/Checkbox/Checkbox.stories.tsx
@@ -1,4 +1,5 @@
 import React, { FormEvent, useState } from "react";
+import { Radioactive } from "@phosphor-icons/react";
 // Components
 import Form from "../Form/Form";
 import Checkbox from "./Checkbox";
@@ -168,4 +169,8 @@ export const Vanilla_Form = () => (
       <Button type="submit">Submit</Button>
     </form>
   </Stack>
+);
+
+export const Custom_Icon = () => (
+  <Checkbox name="checkbox" icon={<Radioactive weight="bold" />} checked />
 );

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -1,4 +1,4 @@
-import { forwardRef } from "react";
+import { forwardRef, ReactNode } from "react";
 import { Check, Minus } from "@phosphor-icons/react";
 // Components
 import Flex, { FlexProps } from "../Flex/Flex";
@@ -14,7 +14,7 @@ import { PrismaneFieldComponent, PrismaneProps } from "../../types";
 import { strip, variants, fr } from "../../utils";
 
 export type CheckboxProps = PrismaneProps<
-  { indeterminate?: boolean },
+  { indeterminate?: boolean; icon?: ReactNode },
   FlexProps & TransitionProps & PrismaneFieldComponent
 >;
 
@@ -22,6 +22,7 @@ const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
   (
     {
       indeterminate = false,
+      icon,
       label,
       error,
       size = "base",
@@ -128,7 +129,13 @@ const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
               className="PrismaneCheckbox-thumb"
             >
               {indeterminate ? (
-                <Minus weight="bold" />
+                icon ? (
+                  icon
+                ) : (
+                  <Minus weight="bold" />
+                )
+              ) : icon ? (
+                icon
               ) : (
                 <Check weight="bold" />
               )}


### PR DESCRIPTION
This merge introduces the new `icon` prop on the `Checkbox` component, which allows change of the default icon of the checkbox field.