### PR TITLE
Fix Custom Alert Action To Close Alert Too

### DIFF
--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -165,6 +165,9 @@ const Alert = forwardRef<HTMLDivElement, AlertProps>(
                 justify="center"
                 align="center"
                 ml={fr(16)}
+                onClick={() => {
+                  setShown(false);
+                }}
                 className={`PrismaneAlert-action PrismaneAlert-action-${variant}`}
               >
                 {action ? (
@@ -178,9 +181,6 @@ const Alert = forwardRef<HTMLDivElement, AlertProps>(
                       success: "green",
                       info: "diamond",
                     })}
-                    onClick={() => {
-                      setShown(false);
-                    }}
                   />
                 )}
               </Flex>


### PR DESCRIPTION
This merge fixes an issue with the `Alert` component, where the custom action component passed to the `action` prop did not close the alert.