### PR TITLE
Spinner Component To Use Icon Component

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -188,7 +188,15 @@ const Button: ButtonComponent = forwardRef(
         {...props}
       >
         {loading ? (
-          <Spinner />
+          <Spinner
+            size={variants(size, {
+              xs: fr(4.75),
+              sm: fr(4.75),
+              base: fr(5.25),
+              md: fr(6.25),
+              lg: fr(7.75),
+            })}
+          />
         ) : (
           <>
             {icon && (

--- a/src/components/Spinner/Spinner.tsx
+++ b/src/components/Spinner/Spinner.tsx
@@ -1,39 +1,17 @@
 import { forwardRef } from "react";
 import { CircleNotch } from "@phosphor-icons/react";
 // Components
-import Flex, { FlexProps } from "../Flex/Flex";
-// Types
-import { PrismaneBreakpoints, PrismaneProps } from "../../types";
+import Icon, { IconProps } from "../Icon/Icon";
 // Utils
-import { strip, variants, fr } from "../../utils";
+import { strip, dual, fr } from "../../utils";
 
-export type SpinnerProps = PrismaneProps<
-  {
-    size?: PrismaneBreakpoints;
-  },
-  FlexProps<"svg">
->;
+export type SpinnerProps = IconProps;
 
 const Spinner = forwardRef<SVGElement, SpinnerProps>(
   ({ size = "base", className, sx, ...props }, ref) => {
     return (
-      <Flex
-        as={CircleNotch}
-        w={variants(size, {
-          xs: fr(4),
-          sm: fr(5),
-          base: fr(6),
-          md: fr(7),
-          lg: fr(8),
-        })}
-        h={variants(size, {
-          xs: fr(4),
-          sm: fr(5),
-          base: fr(6),
-          md: fr(7),
-          lg: fr(8),
-        })}
-        weight="bold"
+      <Icon
+        size={size}
         sx={{
           animation: "prismane-spin linear 0.5s infinite",
           ...sx,
@@ -46,7 +24,9 @@ const Spinner = forwardRef<SVGElement, SpinnerProps>(
         data-testid="prismane-spinner"
         ref={ref}
         {...props}
-      />
+      >
+        <CircleNotch />
+      </Icon>
     );
   }
 );


### PR DESCRIPTION
This merge transitions the `Spinner` component to use the `Icon` component as it's base.