### PR TITLE
fix: fix accordion item children prop type

### DIFF
--- a/src/components/Accordion/AccordionIcon/AccordionIcon.tsx
+++ b/src/components/Accordion/AccordionIcon/AccordionIcon.tsx
@@ -1,4 +1,4 @@
-import { forwardRef } from "react";
+import { ReactNode, forwardRef } from "react";
 import { CaretUp, CaretDown } from "@phosphor-icons/react";
 // Components
 import Flex, { FlexProps } from "../../Flex/Flex";
@@ -6,10 +6,17 @@ import Transition from "../../Transition/Transition";
 // Context
 import { useAccordionContext } from "../AccordionContext";
 import { useAccordionItemContext } from "../AccordionItem/AccordionItemContext";
+// Types
+import { PrismaneProps } from "../../../types";
 // Utils
 import { strip } from "../../../utils";
 
-export type AccordionIconProps = FlexProps;
+export type AccordionIconProps = PrismaneProps<
+  {
+    children?: ReactNode | ((active: boolean) => ReactNode);
+  },
+  FlexProps
+>;
 
 const AccordionIcon = forwardRef<HTMLDivElement, AccordionIconProps>(
   ({ children, className, ...props }, ref) => {


### PR DESCRIPTION
This merge fixes the prop type of the `children` prop of the `Accordion.Item` component.