### PR TITLE
fix: fix autocomplete field filter prop type

### DIFF
--- a/src/components/AutocompleteField/AutocompleteField.tsx
+++ b/src/components/AutocompleteField/AutocompleteField.tsx
@@ -10,7 +10,13 @@ import { strip } from "../../utils";
 
 export type AutocompleteFieldProps = PrismaneProps<
   {
-    filter?: Function;
+    filter?: (
+      value: any,
+      item: {
+        value: string;
+        element: React.ReactNode;
+      }
+    ) => boolean;
   },
   SelectFieldProps
 >;


### PR DESCRIPTION
This merge fixes the prop type of the `filter` prop of the `AutocompleteField` component.