### PR TITLE
fix: fix button's border color with tertiary variant and fill on hover

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -156,8 +156,8 @@ const Button: ButtonComponent = forwardRef(
         bdw={variant === "tertiary" && 1}
         bdc={(theme) =>
           variant === "tertiary" && theme.mode === "dark"
-            ? [color, 500]
-            : [color, 300]
+            ? [[color, 500], { hover: fillOnHover && [color, 700] }]
+            : [[color, 300], { hover: fillOnHover && [color, 500] }]
         }
         pe={[loading && "none", { disabled: "none" }]}
         cs="pointer"


### PR DESCRIPTION
This merge fixes the `Button` component's border color when it has a `tertiary` variant and has a `fillOnHover` prop.