### PR TITLE
refactor: add typescript import paths

### DIFF
--- a/.storybook/storybook.config.js
+++ b/.storybook/storybook.config.js
@@ -21,4 +21,13 @@ export default defineConfig({
       },
     },
   },
+  resolve: {
+    alias: {
+      "@": resolve(__dirname, "../src"),
+      "@components": resolve(__dirname, "../src/components"),
+      "@hooks": resolve(__dirname, "../src/hooks"),
+      "@themes": resolve(__dirname, "../src/themes"),
+      "@validators": resolve(__dirname, "../src/validators"),
+    },
+  },
 });

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -1,26 +1,18 @@
 import { forwardRef, useState } from "react";
 // Components
-import Flex, { FlexProps } from "../Flex/Flex";
+import Flex, { FlexProps } from "@components/Flex";
 // Context
 import { AccordionContextProvider } from "./AccordionContext";
 // Types
-import { PrismaneWithInternal, PrismaneProps } from "../../types";
+import { PrismaneWithInternal, PrismaneProps } from "@/types";
 // Utils
-import { strip } from "../../utils";
+import { strip } from "@/utils";
 
 // Internal Components
-import AccordionControl, {
-  AccordionControlProps,
-} from "./AccordionControl/AccordionControl";
-import AccordionIcon, {
-  AccordionIconProps,
-} from "./AccordionIcon/AccordionIcon";
-import AccordionItem, {
-  AccordionItemProps,
-} from "./AccordionItem/AccordionItem";
-import AccordionPanel, {
-  AccordionPanelProps,
-} from "./AccordionPanel/AccordionPanel";
+import AccordionControl, { AccordionControlProps } from "./AccordionControl";
+import AccordionIcon, { AccordionIconProps } from "./AccordionIcon";
+import AccordionItem, { AccordionItemProps } from "./AccordionItem";
+import AccordionPanel, { AccordionPanelProps } from "./AccordionPanel";
 
 export {
   type AccordionControlProps,

--- a/src/components/Accordion/AccordionControl/AccordionControl.tsx
+++ b/src/components/Accordion/AccordionControl/AccordionControl.tsx
@@ -1,14 +1,14 @@
 import { forwardRef } from "react";
 // Components
-import Flex, { FlexProps } from "../../Flex/Flex";
-import Transition, { TransitionProps } from "../../Transition/Transition";
+import Flex, { FlexProps } from "@components/Flex";
+import Transition, { TransitionProps } from "@components/Transition";
 // Context
 import { useAccordionContext } from "../AccordionContext";
 import { useAccordionItemContext } from "../AccordionItem/AccordionItemContext";
 // Types
-import { PrismaneProps } from "../../../types";
+import { PrismaneProps } from "@/types";
 // Utils
-import { strip, fr } from "../../../utils";
+import { strip, fr } from "@/utils";
 
 export type AccordionControlProps = PrismaneProps<FlexProps, TransitionProps>;
 

--- a/src/components/Accordion/AccordionControl/index.ts
+++ b/src/components/Accordion/AccordionControl/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./AccordionControl";
+export { default, type AccordionControlProps } from "./AccordionControl";

--- a/src/components/Accordion/AccordionIcon/AccordionIcon.tsx
+++ b/src/components/Accordion/AccordionIcon/AccordionIcon.tsx
@@ -1,15 +1,15 @@
 import { ReactNode, forwardRef } from "react";
 import { CaretUp } from "@phosphor-icons/react";
 // Components
-import Flex, { FlexProps } from "../../Flex/Flex";
-import Transition from "../../Transition/Transition";
+import Flex, { FlexProps } from "@components/Flex";
+import Transition from "@components/Transition";
 // Context
 import { useAccordionContext } from "../AccordionContext";
 import { useAccordionItemContext } from "../AccordionItem/AccordionItemContext";
 // Types
-import { PrismaneProps } from "../../../types";
+import { PrismaneProps } from "@/types";
 // Utils
-import { strip } from "../../../utils";
+import { strip } from "@/utils";
 
 export type AccordionIconProps = PrismaneProps<
   {

--- a/src/components/Accordion/AccordionIcon/index.ts
+++ b/src/components/Accordion/AccordionIcon/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./AccordionIcon";
+export { default, type AccordionIconProps } from "./AccordionIcon";

--- a/src/components/Accordion/AccordionItem/AccordionItem.tsx
+++ b/src/components/Accordion/AccordionItem/AccordionItem.tsx
@@ -1,12 +1,12 @@
 import { forwardRef } from "react";
 // Components
-import Flex, { FlexProps } from "../../Flex/Flex";
+import Flex, { FlexProps } from "@components/Flex";
 // Context
 import { AccordionItemContextProvider } from "./AccordionItemContext";
 // Types
-import { PrismaneProps } from "../../../types";
+import { PrismaneProps } from "@/types";
 // Utils
-import { strip } from "../../../utils";
+import { strip } from "@/utils";
 
 export type AccordionItemProps = PrismaneProps<
   {

--- a/src/components/Accordion/AccordionItem/index.ts
+++ b/src/components/Accordion/AccordionItem/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./AccordionItem";
+export { default, type AccordionItemProps } from "./AccordionItem";

--- a/src/components/Accordion/AccordionPanel/AccordionPanel.tsx
+++ b/src/components/Accordion/AccordionPanel/AccordionPanel.tsx
@@ -1,12 +1,12 @@
 import { forwardRef, useRef, useEffect, useState } from "react";
 // Components
-import Box from "../../Box/Box";
-import Animation, { AnimationProps } from "../../Animation/Animation";
+import Box from "@components/Box";
+import Animation, { AnimationProps } from "@components/Animation";
 // Context
 import { useAccordionContext } from "../AccordionContext";
 import { useAccordionItemContext } from "../AccordionItem/AccordionItemContext";
 // Utils
-import { strip, fr } from "../../../utils";
+import { strip, fr } from "@/utils";
 
 export type AccordionPanelProps = AnimationProps;
 

--- a/src/components/Accordion/AccordionPanel/index.ts
+++ b/src/components/Accordion/AccordionPanel/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./AccordionPanel";
+export { default, type AccordionPanelProps } from "./AccordionPanel";

--- a/src/components/ActionButton/ActionButton.tsx
+++ b/src/components/ActionButton/ActionButton.tsx
@@ -1,8 +1,8 @@
 import { forwardRef } from "react";
 // Components
-import Button, { ButtonProps } from "../Button/Button";
+import Button, { ButtonProps } from "@components/Button";
 // Utils
-import { fr, variants } from "../../utils";
+import { fr, variants } from "@/utils";
 
 export type ActionButtonProps = ButtonProps;
 

--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -6,26 +6,20 @@ import {
   Info,
 } from "@phosphor-icons/react";
 // Components
-import Animation, { AnimationProps } from "../Animation/Animation";
-import Flex, { FlexProps } from "../Flex/Flex";
-import CloseButton from "../CloseButton/CloseButton";
+import Animation, { AnimationProps } from "@components/Animation";
+import Flex, { FlexProps } from "@components/Flex";
+import CloseButton from "@components/CloseButton";
 // Hooks
-import useAnimation from "../../hooks/useAnimation";
-import usePresence from "../../hooks/usePresence";
+import useAnimation from "@hooks/useAnimation";
+import usePresence from "@hooks/usePresence";
 // Types
-import {
-  PrismaneActions,
-  PrismaneWithInternal,
-  PrismaneProps,
-} from "../../types";
+import { PrismaneActions, PrismaneWithInternal, PrismaneProps } from "@/types";
 // Utils
-import { strip, variants, fr } from "../../utils";
+import { strip, variants, fr } from "@/utils";
 
 // Internal Components
-import AlertTitle, { AlertTitleProps } from "./AlertTitle/AlertTitle";
-import AlertDescription, {
-  AlertDescriptionProps,
-} from "./AlertDescription/AlertDescription";
+import AlertTitle, { AlertTitleProps } from "./AlertTitle";
+import AlertDescription, { AlertDescriptionProps } from "./AlertDescription";
 
 export { type AlertTitleProps, type AlertDescriptionProps };
 

--- a/src/components/Alert/AlertDescription/AlertDescription.tsx
+++ b/src/components/Alert/AlertDescription/AlertDescription.tsx
@@ -1,8 +1,8 @@
 import { forwardRef } from "react";
 // Components
-import Text, { TextProps } from "../../Text/Text";
+import Text, { TextProps } from "@components/Text";
 // Utils
-import { strip } from "../../../utils";
+import { strip } from "@/utils";
 
 export type AlertDescriptionProps = TextProps;
 

--- a/src/components/Alert/AlertDescription/index.ts
+++ b/src/components/Alert/AlertDescription/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./AlertDescription";
+export { default, type AlertDescriptionProps } from "./AlertDescription";

--- a/src/components/Alert/AlertTitle/AlertTitle.tsx
+++ b/src/components/Alert/AlertTitle/AlertTitle.tsx
@@ -1,8 +1,8 @@
 import { forwardRef } from "react";
 // Components
-import Text, { TextProps } from "../../Text/Text";
+import Text, { TextProps } from "@components/Text";
 // Utils
-import { strip } from "../../../utils";
+import { strip } from "@/utils";
 
 export type AlertTitleProps = TextProps;
 

--- a/src/components/Alert/AlertTitle/index.ts
+++ b/src/components/Alert/AlertTitle/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./AlertTitle";
+export { default, type AlertTitleProps } from "./AlertTitle";

--- a/src/components/Animation/Animation.tsx
+++ b/src/components/Animation/Animation.tsx
@@ -1,6 +1,6 @@
 import { forwardRef, useEffect, useState } from "react";
 // Components
-import Transition, { TransitionProps } from "../Transition/Transition";
+import Transition, { TransitionProps } from "@components/Transition";
 // Types
 import {
   PrismaneAnimations,
@@ -8,9 +8,9 @@ import {
   PrismaneVersatile,
   PrismaneVersatileRef,
   PrismaneProps,
-} from "../../types";
+} from "@/types";
 // Utils
-import { strip } from "../../utils";
+import { strip } from "@/utils";
 
 export interface Animation {
   in: object;

--- a/src/components/AspectRatio/AspectRatio.tsx
+++ b/src/components/AspectRatio/AspectRatio.tsx
@@ -1,10 +1,10 @@
 import { forwardRef } from "react";
 // Components
-import Box, { BoxProps } from "../Box/Box";
+import Box, { BoxProps } from "@components/Box";
 // Types
-import { PrismaneStyles, PrismaneProps } from "../../types";
+import { PrismaneStyles, PrismaneProps } from "@/types";
 // Utils
-import { strip } from "../../utils";
+import { strip } from "@/utils";
 
 export type AspectRatioProps = PrismaneProps<
   {

--- a/src/components/AutocompleteField/AutocompleteField.tsx
+++ b/src/components/AutocompleteField/AutocompleteField.tsx
@@ -1,12 +1,12 @@
 import { forwardRef, useState, useEffect } from "react";
 // Components
-import SelectField, { SelectFieldProps } from "../SelectField/SelectField";
+import SelectField, { SelectFieldProps } from "@components/SelectField";
 // Hooks
-import useDebounce from "../../hooks/useDebounce";
+import useDebounce from "@hooks/useDebounce";
 // Types
-import { PrismaneProps } from "../../types";
+import { PrismaneProps } from "@/types";
 // Utils
-import { strip } from "../../utils";
+import { strip } from "@/utils";
 
 export type AutocompleteFieldProps = PrismaneProps<
   {

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -1,11 +1,11 @@
 import { forwardRef } from "react";
 import { UserCircle } from "@phosphor-icons/react";
 // Components
-import Center from "../Center/Center";
-import Circle, { CircleProps } from "../Circle/Circle";
-import Flex from "../Flex/Flex";
-import Icon from "../Icon/Icon";
-import Image from "../Image/Image";
+import Center from "@components/Center";
+import Circle, { CircleProps } from "@components/Circle";
+import Flex from "@components/Flex";
+import Icon from "@components/Icon";
+import Image from "@components/Image";
 // Types
 import {
   PrismaneColors,
@@ -14,9 +14,9 @@ import {
   PrismaneVersatile,
   PrismaneVersatileRef,
   PrismaneProps,
-} from "../../types";
+} from "@/types";
 // Utils
-import { strip, variants, fr } from "../../utils";
+import { strip, variants, fr } from "@/utils";
 
 export type AvatarProps<E extends Versatile = "div"> = PrismaneVersatile<
   E,

--- a/src/components/Backdrop/Backdrop.tsx
+++ b/src/components/Backdrop/Backdrop.tsx
@@ -1,8 +1,8 @@
 import { forwardRef } from "react";
 // Components
-import Center, { CenterProps } from "../Center/Center";
+import Center, { CenterProps } from "@components/Center";
 // Utils
-import { strip } from "../../utils";
+import { strip } from "@/utils";
 
 export type BackdropProps = CenterProps;
 

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -1,7 +1,7 @@
 import { forwardRef, ReactNode } from "react";
 // Components
-import Box from "../Box/Box";
-import Center, { CenterProps } from "../Center/Center";
+import Box from "@components/Box";
+import Center, { CenterProps } from "@components/Center";
 // Types
 import {
   PrismaneColors,
@@ -11,9 +11,9 @@ import {
   PrismaneVersatile,
   PrismaneVersatileRef,
   PrismaneProps,
-} from "../../types";
+} from "@/types";
 // Utils
-import { strip, variants, fr } from "../../utils";
+import { strip, variants, fr } from "@/utils";
 
 export type BadgeProps<E extends Versatile = "div"> = PrismaneVersatile<
   E,

--- a/src/components/Box/Box.tsx
+++ b/src/components/Box/Box.tsx
@@ -1,18 +1,18 @@
 import { forwardRef } from "react";
 // Hooks
-import useStyling from "../../hooks/useStyling";
-import usePrismaneColor from "../PrismaneProvider/usePrismaneColor";
+import useStyling from "@hooks/useStyling";
+import usePrismaneColor from "@components/PrismaneProvider/usePrismaneColor";
 // Theme
-import { usePrismaneTheme } from "../PrismaneProvider/PrismaneContext";
+import { usePrismaneTheme } from "@components/PrismaneProvider/PrismaneContext";
 // Types
 import {
   PrismaneComponent,
   PrismaneVersatile,
   Versatile,
   PrismaneVersatileRef,
-} from "../../types";
+} from "@/types";
 // Utils
-import { strip, dual, variants, fr } from "../../utils";
+import { strip, dual, variants, fr } from "@/utils";
 
 export type BoxProps<E extends Versatile = "div"> = PrismaneVersatile<
   E,

--- a/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.tsx
@@ -1,18 +1,16 @@
 import { forwardRef } from "react";
 // Components
-import Flex, { FlexProps } from "../Flex/Flex";
+import Flex, { FlexProps } from "@components/Flex";
 // Types
-import { PrismaneWithInternal } from "../../types";
+import { PrismaneWithInternal } from "@/types";
 // Utils
-import { strip, fr } from "../../utils";
+import { strip, fr } from "@/utils";
 
 // Internal Components
-import BreadcrumbItem, {
-  BreadcrumbItemProps,
-} from "./BreadcrumbItem/BreadcrumbItem";
+import BreadcrumbItem, { BreadcrumbItemProps } from "./BreadcrumbItem";
 import BreadcrumbSeparator, {
   BreadcrumbSeparatorProps,
-} from "./BreadcrumbSeparator/BreadcrumbSeparator";
+} from "./BreadcrumbSeparator";
 
 export { type BreadcrumbItemProps, type BreadcrumbSeparatorProps };
 

--- a/src/components/Breadcrumb/BreadcrumbItem/BreadcrumbItem.tsx
+++ b/src/components/Breadcrumb/BreadcrumbItem/BreadcrumbItem.tsx
@@ -1,15 +1,11 @@
 import { forwardRef } from "react";
 // Components
-import Flex, { FlexProps } from "../../Flex/Flex";
-import Link from "../../Link/Link";
+import Flex, { FlexProps } from "@components/Flex";
+import Link from "@components/Link";
 // Types
-import {
-  Versatile,
-  PrismaneVersatile,
-  PrismaneVersatileRef,
-} from "../../../types";
+import { Versatile, PrismaneVersatile, PrismaneVersatileRef } from "@/types";
 // Utils
-import { strip } from "../../../utils";
+import { strip } from "@/utils";
 
 export type BreadcrumbItemProps<E extends Versatile = typeof Link> =
   PrismaneVersatile<E, FlexProps>;

--- a/src/components/Breadcrumb/BreadcrumbItem/index.ts
+++ b/src/components/Breadcrumb/BreadcrumbItem/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./BreadcrumbItem";
+export { default, type BreadcrumbItemProps } from "./BreadcrumbItem";

--- a/src/components/Breadcrumb/BreadcrumbSeparator/BreadcrumbSeparator.tsx
+++ b/src/components/Breadcrumb/BreadcrumbSeparator/BreadcrumbSeparator.tsx
@@ -1,8 +1,8 @@
 import { forwardRef } from "react";
 // Components
-import Flex, { FlexProps } from "../../Flex/Flex";
+import Flex, { FlexProps } from "@components/Flex";
 // Utils
-import { strip } from "../../../utils";
+import { strip } from "@/utils";
 
 export type BreadcrumbSeparatorProps = FlexProps;
 

--- a/src/components/Breadcrumb/BreadcrumbSeparator/index.ts
+++ b/src/components/Breadcrumb/BreadcrumbSeparator/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./BreadcrumbSeparator";
+export { default, type BreadcrumbSeparatorProps } from "./BreadcrumbSeparator";

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,9 +1,9 @@
 import { forwardRef, ReactNode } from "react";
 // Components
-import Transition, { TransitionProps } from "../Transition/Transition";
-import Text from "../Text/Text";
-import Icon from "../Icon/Icon";
-import Spinner from "../Spinner/Spinner";
+import Transition, { TransitionProps } from "@components/Transition";
+import Text from "@components/Text";
+import Icon from "@components/Icon";
+import Spinner from "@components/Spinner";
 // Types
 import {
   PrismaneBreakpoints,
@@ -12,9 +12,9 @@ import {
   PrismaneVersatile,
   PrismaneVersatileRef,
   PrismaneProps,
-} from "../../types";
+} from "@/types";
 // Utils
-import { strip, variants, fr } from "../../utils";
+import { strip, variants, fr } from "@/utils";
 
 export type ButtonProps<E extends Versatile = "button"> = PrismaneVersatile<
   E,

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -1,19 +1,19 @@
 import { forwardRef } from "react";
 // Component
-import Paper, { PaperProps } from "../Paper/Paper";
+import Paper, { PaperProps } from "@components/Paper";
 // Types
 import {
   PrismaneWithInternal,
   Versatile,
   PrismaneVersatile,
   PrismaneVersatileRef,
-} from "../../types";
+} from "@/types";
 // Utils
-import { strip, fr } from "../../utils";
+import { strip, fr } from "@/utils";
 
 // Internal Components
-import CardHeader, { CardHeaderProps } from "./CardHeader/CardHeader";
-import CardFooter, { CardFooterProps } from "./CardFooter/CardFooter";
+import CardHeader, { CardHeaderProps } from "./CardHeader";
+import CardFooter, { CardFooterProps } from "./CardFooter";
 
 export { type CardHeaderProps, type CardFooterProps };
 

--- a/src/components/Card/CardFooter/CardFooter.tsx
+++ b/src/components/Card/CardFooter/CardFooter.tsx
@@ -1,8 +1,8 @@
 import { forwardRef } from "react";
 // Components
-import Flex, { FlexProps } from "../../Flex/Flex";
+import Flex, { FlexProps } from "@components/Flex";
 // Utils
-import { strip, fr } from "../../../utils";
+import { strip, fr } from "@/utils";
 
 export type CardFooterProps = FlexProps;
 

--- a/src/components/Card/CardFooter/index.ts
+++ b/src/components/Card/CardFooter/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./CardFooter";
+export { default, type CardFooterProps } from "./CardFooter";

--- a/src/components/Card/CardHeader/CardHeader.tsx
+++ b/src/components/Card/CardHeader/CardHeader.tsx
@@ -1,8 +1,8 @@
 import { forwardRef } from "react";
 // Components
-import Flex, { FlexProps } from "../../Flex/Flex";
+import Flex, { FlexProps } from "@components/Flex";
 // Utils
-import { strip, fr } from "../../../utils";
+import { strip, fr } from "@/utils";
 
 export type CardHeaderProps = FlexProps;
 

--- a/src/components/Card/CardHeader/index.ts
+++ b/src/components/Card/CardHeader/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./CardHeader";
+export { default, type CardHeaderProps } from "./CardHeader";

--- a/src/components/Center/Center.tsx
+++ b/src/components/Center/Center.tsx
@@ -1,14 +1,10 @@
 import { forwardRef } from "react";
 // Components
-import Flex, { FlexProps } from "../Flex/Flex";
+import Flex, { FlexProps } from "@components/Flex";
 // Types
-import {
-  Versatile,
-  PrismaneVersatile,
-  PrismaneVersatileRef,
-} from "../../types";
+import { Versatile, PrismaneVersatile, PrismaneVersatileRef } from "@/types";
 // Utils
-import { strip } from "../../utils";
+import { strip } from "@/utils";
 
 export type CenterProps<E extends Versatile = "div"> = PrismaneVersatile<
   E,

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -1,17 +1,15 @@
 import { forwardRef, ReactNode } from "react";
 import { Check, Minus } from "@phosphor-icons/react";
 // Components
-import Flex, { FlexProps } from "../Flex/Flex";
-import Transition, { TransitionProps } from "../Transition/Transition";
-import Field from "../Field/Field";
-import Animation from "../Animation/Animation";
-import Hidden from "../Hidden/Hidden";
-// Hooks
-import { useFieldProps } from "../Field";
+import Flex, { FlexProps } from "@components/Flex";
+import Transition, { TransitionProps } from "@components/Transition";
+import Field, { useFieldProps } from "@components/Field";
+import Animation from "@components/Animation";
+import Hidden from "@components/Hidden";
 // Types
-import { PrismaneFieldComponent, PrismaneProps } from "../../types";
+import { PrismaneFieldComponent, PrismaneProps } from "@/types";
 // Utils
-import { strip, variants, fr } from "../../utils";
+import { strip, variants, fr } from "@/utils";
 
 export type CheckboxProps = PrismaneProps<
   { indeterminate?: boolean; icon?: ReactNode },

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -1,17 +1,13 @@
 import { forwardRef, ReactNode } from "react";
 // Components
-import Flex, { FlexProps } from "../Flex/Flex";
-import Transition, { TransitionProps } from "../Transition/Transition";
-import Icon from "../Icon/Icon";
-import Text from "../Text/Text";
+import Flex, { FlexProps } from "@components/Flex";
+import Transition, { TransitionProps } from "@components/Transition";
+import Icon from "@components/Icon";
+import Text from "@components/Text";
 // Types
-import {
-  PrismaneColors,
-  PrismaneBreakpoints,
-  PrismaneProps,
-} from "../../types";
+import { PrismaneColors, PrismaneBreakpoints, PrismaneProps } from "@/types";
 // Utils
-import { strip, variants, fr } from "../../utils";
+import { strip, variants, fr } from "@/utils";
 
 export type ChipProps = PrismaneProps<
   {

--- a/src/components/Circle/Circle.tsx
+++ b/src/components/Circle/Circle.tsx
@@ -1,6 +1,6 @@
 import { forwardRef } from "react";
 // Components
-import Center, { CenterProps } from "../Center/Center";
+import Center, { CenterProps } from "@components/Center";
 // Types
 import {
   PrismaneStyles,
@@ -8,9 +8,9 @@ import {
   PrismaneVersatile,
   PrismaneVersatileRef,
   PrismaneProps,
-} from "../../types";
+} from "@/types";
 // Utils
-import { strip } from "../../utils";
+import { strip } from "@/utils";
 
 export type CircleProps<E extends Versatile = "div"> = PrismaneVersatile<
   E,

--- a/src/components/CloseButton/CloseButton.tsx
+++ b/src/components/CloseButton/CloseButton.tsx
@@ -1,9 +1,9 @@
 import { forwardRef } from "react";
 import { X } from "@phosphor-icons/react";
 // Components
-import ActionButton, { ActionButtonProps } from "../ActionButton/ActionButton";
+import ActionButton, { ActionButtonProps } from "@components/ActionButton";
 // Utils
-import { variants } from "../../utils";
+import { variants } from "@/utils";
 
 export type CloseButtonProps = ActionButtonProps;
 

--- a/src/components/Collapse/Collapse.tsx
+++ b/src/components/Collapse/Collapse.tsx
@@ -1,11 +1,11 @@
 import { forwardRef, useRef } from "react";
 // Components
-import Animation, { AnimationProps } from "../Animation/Animation";
-import Box from "../Box/Box";
+import Animation, { AnimationProps } from "@components/Animation";
+import Box from "@components/Box";
 // Types
-import { PrismaneProps } from "../../types";
+import { PrismaneProps } from "@/types";
 // Utils
-import { strip } from "../../utils";
+import { strip } from "@/utils";
 
 export type CollapseProps = PrismaneProps<
   {

--- a/src/components/ColorField/ColorField.tsx
+++ b/src/components/ColorField/ColorField.tsx
@@ -1,17 +1,17 @@
 import { forwardRef } from "react";
 // Components
-import SelectField, { SelectFieldProps } from "../SelectField/SelectField";
-import Field from "../Field/Field";
-import Circle from "../Circle/Circle";
-import Transition from "../Transition/Transition";
+import SelectField, { SelectFieldProps } from "@components/SelectField";
+import Field from "@components/Field";
+import Circle from "@components/Circle";
+import Transition from "@components/Transition";
 // Hooks
-import usePrismaneColor from "../PrismaneProvider/usePrismaneColor";
+import usePrismaneColor from "@components/PrismaneProvider/usePrismaneColor";
 // Globals
-import { PRISMANE_DEFAULT_COLORS_MAP } from "../../constants";
+import { PRISMANE_DEFAULT_COLORS_MAP } from "@/constants";
 // Types
-import { PrismaneColors, PrismaneProps } from "../../types";
+import { PrismaneColors, PrismaneProps } from "@/types";
 // Utils
-import { strip, fr } from "../../utils";
+import { strip, fr } from "@/utils";
 
 export type ColorFieldProps = PrismaneProps<
   {

--- a/src/components/Container/Container.tsx
+++ b/src/components/Container/Container.tsx
@@ -1,10 +1,10 @@
 import { forwardRef } from "react";
 // Components
-import Flex, { FlexProps } from "../Flex/Flex";
+import Flex, { FlexProps } from "@components/Flex";
 // Types
-import { PrismaneBreakpoints, PrismaneProps } from "../../types";
+import { PrismaneBreakpoints, PrismaneProps } from "@/types";
 // Utils
-import { strip } from "../../utils";
+import { strip } from "@/utils";
 
 export type ContainerProps = PrismaneProps<
   {

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -1,13 +1,13 @@
 import { forwardRef, useEffect } from "react";
 // Components
-import Animation, { AnimationProps } from "../Animation/Animation";
-import Paper from "../Paper/Paper";
-import Portal from "../Portal/Portal";
-import Backdrop from "../Backdrop/Backdrop";
+import Animation, { AnimationProps } from "@components/Animation";
+import Paper from "@components/Paper";
+import Portal from "@components/Portal";
+import Backdrop from "@components/Backdrop";
 // Hooks
-import usePresence from "../../hooks/usePresence";
-import useAnimation from "../../hooks/useAnimation";
-import useKeyboardShortcut from "../../hooks/useKeyboardShortcut";
+import usePresence from "@/hooks/usePresence";
+import useAnimation from "@/hooks/useAnimation";
+import useKeyboardShortcut from "@/hooks/useKeyboardShortcut";
 // Context
 import { DialogContextProvider } from "./DialogContext";
 // Types
@@ -15,13 +15,13 @@ import {
   PrismaneWithInternal,
   PrismanePositions,
   PrismaneProps,
-} from "../../types";
+} from "@/types";
 // Utils
-import { strip, fr, variants } from "../../utils";
+import { strip, fr, variants } from "@/utils";
 
 // Internal Components
-import DialogHeader, { DialogHeaderProps } from "./DialogHeader/DialogHeader";
-import DialogFooter, { DialogFooterProps } from "./DialogFooter/DialogFooter";
+import DialogHeader, { DialogHeaderProps } from "./DialogHeader";
+import DialogFooter, { DialogFooterProps } from "./DialogFooter";
 
 export { type DialogHeaderProps, type DialogFooterProps };
 

--- a/src/components/Dialog/DialogFooter/DialogFooter.tsx
+++ b/src/components/Dialog/DialogFooter/DialogFooter.tsx
@@ -1,8 +1,8 @@
 import { forwardRef } from "react";
 // Components
-import Flex, { FlexProps } from "../../Flex/Flex";
+import Flex, { FlexProps } from "@components/Flex";
 // Utils
-import { strip, fr } from "../../../utils";
+import { strip, fr } from "@/utils";
 
 export type DialogFooterProps = FlexProps;
 

--- a/src/components/Dialog/DialogFooter/index.ts
+++ b/src/components/Dialog/DialogFooter/index.ts
@@ -1,0 +1,1 @@
+export { default, type DialogFooterProps } from "./DialogFooter";

--- a/src/components/Dialog/DialogHeader/DialogHeader.tsx
+++ b/src/components/Dialog/DialogHeader/DialogHeader.tsx
@@ -1,11 +1,11 @@
 import { forwardRef } from "react";
 // Components
-import Flex, { FlexProps } from "../../Flex/Flex";
-import CloseButton from "../../CloseButton/CloseButton";
+import Flex, { FlexProps } from "@components/Flex";
+import CloseButton from "@components/CloseButton";
 // Context
 import { useDialogContext } from "../DialogContext";
 // Utils
-import { strip, fr } from "../../../utils";
+import { strip, fr } from "@/utils";
 
 export type DialogHeaderProps = FlexProps;
 

--- a/src/components/Dialog/DialogHeader/index.ts
+++ b/src/components/Dialog/DialogHeader/index.ts
@@ -1,0 +1,1 @@
+export { default, type DialogHeaderProps } from "./DialogHeader";

--- a/src/components/Divider/Divider.tsx
+++ b/src/components/Divider/Divider.tsx
@@ -1,10 +1,10 @@
 import { forwardRef } from "react";
 // Components
-import Flex, { FlexProps } from "../Flex/Flex";
+import Flex, { FlexProps } from "@components/Flex";
 // Types
-import { PrismaneProps, PrismaneBreakpoints } from "../../types";
+import { PrismaneProps, PrismaneBreakpoints } from "@/types";
 // Utils
-import { strip, variants } from "../../utils";
+import { strip, variants } from "@/utils";
 
 export type DividerProps = PrismaneProps<
   {

--- a/src/components/Drawer/Drawer.tsx
+++ b/src/components/Drawer/Drawer.tsx
@@ -1,13 +1,13 @@
 import { forwardRef, useEffect } from "react";
 // Components
-import Paper, { PaperProps } from "../Paper/Paper";
-import Animation, { AnimationProps } from "../Animation/Animation";
-import Backdrop from "../Backdrop/Backdrop";
-import Portal from "../Portal/Portal";
+import Paper, { PaperProps } from "@components/Paper";
+import Animation, { AnimationProps } from "@components/Animation";
+import Backdrop from "@components/Backdrop";
+import Portal from "@components/Portal";
 // Hooks
-import useAnimation from "../../hooks/useAnimation";
-import usePresence from "../../hooks/usePresence";
-import useKeyboardShortcut from "../../hooks/useKeyboardShortcut";
+import useAnimation from "@hooks/useAnimation";
+import usePresence from "@hooks/usePresence";
+import useKeyboardShortcut from "@hooks/useKeyboardShortcut";
 // Context
 import { DrawerContextProvider } from "./DrawerContext";
 // Types
@@ -15,12 +15,12 @@ import {
   PrismaneWithInternal,
   PrismaneBreakpoints,
   PrismaneProps,
-} from "../../types";
+} from "@/types";
 // Utils
-import { strip, variants, dual, fr } from "../../utils";
+import { strip, variants, dual, fr } from "@/utils";
 // Internal Components
-import DrawerHeader, { DrawerHeaderProps } from "./DrawerHeader/DrawerHeader";
-import DrawerFooter, { DrawerFooterProps } from "./DrawerFooter/DrawerFooter";
+import DrawerHeader, { DrawerHeaderProps } from "./DrawerHeader";
+import DrawerFooter, { DrawerFooterProps } from "./DrawerFooter";
 
 export { type DrawerHeaderProps, type DrawerFooterProps };
 

--- a/src/components/Drawer/DrawerFooter/DrawerFooter.tsx
+++ b/src/components/Drawer/DrawerFooter/DrawerFooter.tsx
@@ -1,8 +1,8 @@
 import { forwardRef } from "react";
 // Components
-import Flex, { FlexProps } from "../../Flex/Flex";
+import Flex, { FlexProps } from "@components/Flex";
 // Utils
-import { strip, fr } from "../../../utils";
+import { strip, fr } from "@/utils";
 
 export type DrawerFooterProps = FlexProps;
 

--- a/src/components/Drawer/DrawerFooter/index.ts
+++ b/src/components/Drawer/DrawerFooter/index.ts
@@ -1,0 +1,1 @@
+export { default, type DrawerFooterProps } from "./DrawerFooter";

--- a/src/components/Drawer/DrawerHeader/DrawerHeader.tsx
+++ b/src/components/Drawer/DrawerHeader/DrawerHeader.tsx
@@ -1,11 +1,11 @@
 import { forwardRef } from "react";
 // Components
-import Flex, { FlexProps } from "../../Flex/Flex";
-import CloseButton from "../../CloseButton/CloseButton";
+import Flex, { FlexProps } from "@components/Flex";
+import CloseButton from "@components/CloseButton";
 // Context
 import { useDrawerContext } from "../DrawerContext";
 // Utils
-import { strip, fr } from "../../../utils";
+import { strip, fr } from "@/utils";
 
 export type DrawerHeaderProps = FlexProps;
 

--- a/src/components/Drawer/DrawerHeader/index.ts
+++ b/src/components/Drawer/DrawerHeader/index.ts
@@ -1,0 +1,1 @@
+export { default, type DrawerHeaderProps } from "./DrawerHeader";

--- a/src/components/Field/Field.tsx
+++ b/src/components/Field/Field.tsx
@@ -1,10 +1,10 @@
 import { forwardRef, ReactNode } from "react";
 // Components
-import Box from "../Box/Box";
-import Flex, { FlexProps } from "../Flex/Flex";
-import Transition, { TransitionProps } from "../Transition/Transition";
-import Icon from "../Icon/Icon";
-import Spinner from "../Spinner/Spinner";
+import Box from "@components/Box";
+import Flex, { FlexProps } from "@components/Flex";
+import Transition, { TransitionProps } from "@components/Transition";
+import Icon from "@components/Icon";
+import Spinner from "@components/Spinner";
 // Types
 import {
   PrismaneFieldComponent,
@@ -13,18 +13,18 @@ import {
   PrismaneVersatile,
   PrismaneVersatileRef,
   PrismaneProps,
-} from "../../types";
+} from "@/types";
 // Hooks
 import { usePrismaneColor } from "../PrismaneProvider";
 import useFieldProps from "./useFieldProps";
 // Utils
-import { strip, variants, fr } from "../../utils";
+import { strip, variants, fr } from "@/utils";
 
 // Internal Components
-import FieldError, { FieldErrorProps } from "./FieldError/FieldError";
-import FieldLabel, { FieldLabelProps } from "./FieldLabel/FieldLabel";
-import FieldWrapper, { FieldWrapperProps } from "./FieldWrapper/FieldWrapper";
-import FieldAddon, { FieldAddonProps } from "./FieldAddon/FieldAddon";
+import FieldError, { FieldErrorProps } from "./FieldError";
+import FieldLabel, { FieldLabelProps } from "./FieldLabel";
+import FieldWrapper, { FieldWrapperProps } from "./FieldWrapper";
+import FieldAddon, { FieldAddonProps } from "./FieldAddon";
 
 export {
   type FieldErrorProps,

--- a/src/components/Field/FieldAddon/FieldAddon.tsx
+++ b/src/components/Field/FieldAddon/FieldAddon.tsx
@@ -1,11 +1,11 @@
 import { forwardRef } from "react";
 // Components
-import Transition, { TransitionProps } from "../../Transition/Transition";
-import Flex, { FlexProps } from "../../Flex/Flex";
+import Transition, { TransitionProps } from "@components/Transition";
+import Flex, { FlexProps } from "@components/Flex";
 // Types
-import { PrismaneBreakpoints, PrismaneProps } from "../../../types";
+import { PrismaneBreakpoints, PrismaneProps } from "@/types";
 // Utils
-import { strip, variants, fr } from "../../../utils";
+import { strip, variants, fr } from "@/utils";
 
 export type FieldAddonProps = PrismaneProps<
   {

--- a/src/components/Field/FieldAddon/index.ts
+++ b/src/components/Field/FieldAddon/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./FieldAddon";
+export { default, type FieldAddonProps } from "./FieldAddon";

--- a/src/components/Field/FieldError/FieldError.tsx
+++ b/src/components/Field/FieldError/FieldError.tsx
@@ -1,11 +1,11 @@
 import { forwardRef } from "react";
 // Components
-import Flex, { FlexProps } from "../../Flex/Flex";
-import Animation, { AnimationProps } from "../../Animation/Animation";
+import Flex, { FlexProps } from "@components/Flex";
+import Animation, { AnimationProps } from "@components/Animation";
 // Types
-import { PrismaneBreakpoints, PrismaneProps } from "../../../types";
+import { PrismaneBreakpoints, PrismaneProps } from "@/types";
 // Utils
-import { strip, variants, fr } from "../../../utils";
+import { strip, variants, fr } from "@/utils";
 
 export type FieldErrorProps = PrismaneProps<
   {

--- a/src/components/Field/FieldError/index.ts
+++ b/src/components/Field/FieldError/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./FieldError";
+export { default, type FieldErrorProps } from "./FieldError";

--- a/src/components/Field/FieldLabel/FieldLabel.tsx
+++ b/src/components/Field/FieldLabel/FieldLabel.tsx
@@ -1,10 +1,10 @@
 import { forwardRef } from "react";
 // Components
-import Text, { TextProps } from "../../Text/Text";
+import Text, { TextProps } from "@components/Text";
 // Types
-import { PrismaneBreakpoints, PrismaneProps } from "../../../types";
+import { PrismaneBreakpoints, PrismaneProps } from "@/types";
 // Utils
-import { strip, variants } from "../../../utils";
+import { strip, variants } from "@/utils";
 
 export type FieldLabelProps = PrismaneProps<
   {

--- a/src/components/Field/FieldLabel/index.ts
+++ b/src/components/Field/FieldLabel/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./FieldLabel";
+export { default, type FieldLabelProps } from "./FieldLabel";

--- a/src/components/Field/FieldWrapper/FieldWrapper.tsx
+++ b/src/components/Field/FieldWrapper/FieldWrapper.tsx
@@ -1,8 +1,8 @@
 import { forwardRef } from "react";
 // Components
-import Flex, { FlexProps } from "../../Flex/Flex";
+import Flex, { FlexProps } from "@components/Flex";
 // Utils
-import { strip, fr } from "../../../utils";
+import { strip, fr } from "@/utils";
 
 export type FieldWrapperProps = FlexProps;
 

--- a/src/components/Field/FieldWrapper/index.ts
+++ b/src/components/Field/FieldWrapper/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./FieldWrapper";
+export { default, type FieldWrapperProps } from "./FieldWrapper";

--- a/src/components/Flex/Flex.tsx
+++ b/src/components/Flex/Flex.tsx
@@ -1,15 +1,15 @@
 import { forwardRef } from "react";
 // Components
-import Box, { BoxProps } from "../Box/Box";
+import Box, { BoxProps } from "@components/Box";
 // Types
 import {
   Versatile,
   PrismaneVersatile,
   PrismaneVersatileRef,
   PrismaneProps,
-} from "../../types";
+} from "@/types";
 // Utils
-import { strip, variants } from "../../utils";
+import { strip, variants } from "@/utils";
 
 export type FlexProps<E extends Versatile = "div"> = PrismaneVersatile<
   E,

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -1,8 +1,8 @@
 import { forwardRef } from "react";
 // Components
-import Flex, { FlexProps } from "../Flex/Flex";
+import Flex, { FlexProps } from "@components/Flex";
 // Utils
-import { strip } from "../../utils";
+import { strip } from "@/utils";
 
 export type FooterProps = FlexProps<"footer">;
 

--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -1,8 +1,8 @@
 import { forwardRef } from "react";
 // Components
-import Box, { BoxProps } from "../Box/Box";
+import Box, { BoxProps } from "@components/Box";
 // Utils
-import { strip, fr } from "../../utils";
+import { strip, fr } from "@/utils";
 
 export type FormProps = BoxProps<"form">;
 

--- a/src/components/Gradient/Gradient.tsx
+++ b/src/components/Gradient/Gradient.tsx
@@ -1,9 +1,9 @@
 import { forwardRef } from "react";
 import * as CSS from "csstype";
 // Component
-import Box, { BoxProps } from "../Box/Box";
+import Box, { BoxProps } from "@components/Box";
 // Hooks
-import usePrismaneColor from "../PrismaneProvider/usePrismaneColor";
+import usePrismaneColor from "@components/PrismaneProvider/usePrismaneColor";
 // Types
 import {
   Versatile,
@@ -12,9 +12,9 @@ import {
   PrismaneProps,
   PrismaneColors,
   PrismaneShades,
-} from "../../types";
+} from "@/types";
 // Utils
-import { strip } from "../../utils";
+import { strip } from "@/utils";
 
 export type GradientProps<E extends Versatile = "div"> = PrismaneVersatile<
   E,

--- a/src/components/Grid/Grid.tsx
+++ b/src/components/Grid/Grid.tsx
@@ -1,13 +1,13 @@
 import { forwardRef } from "react";
 // Components
-import Box, { BoxProps } from "../Box/Box";
+import Box, { BoxProps } from "@components/Box";
 // Types
-import { PrismaneProps, PrismaneWithInternal } from "../../types";
+import { PrismaneProps, PrismaneWithInternal } from "@/types";
 // Utils
-import { strip, variants } from "../../utils";
+import { strip, variants } from "@/utils";
 
 // Internal Components
-import GridItem, { GridItemProps } from "./GridItem/GridItem";
+import GridItem, { GridItemProps } from "./GridItem";
 
 export { type GridItemProps };
 

--- a/src/components/Grid/GridItem/GridItem.tsx
+++ b/src/components/Grid/GridItem/GridItem.tsx
@@ -1,10 +1,10 @@
 import { forwardRef } from "react";
 // Components
-import Flex, { FlexProps } from "../../Flex/Flex";
+import Flex, { FlexProps } from "@components/Flex";
 // Types
-import { PrismaneProps } from "../../../types";
+import { PrismaneProps } from "@/types";
 // Utils
-import { strip, variants } from "../../../utils";
+import { strip, variants } from "@/utils";
 
 export type GridItemProps = PrismaneProps<
   {

--- a/src/components/Grid/GridItem/index.ts
+++ b/src/components/Grid/GridItem/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./GridItem";
+export { default, type GridItemProps } from "./GridItem";

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,8 +1,8 @@
 import { forwardRef } from "react";
 // Components
-import Flex, { FlexProps } from "../Flex/Flex";
+import Flex, { FlexProps } from "@components/Flex";
 // Utils
-import { strip } from "../../utils";
+import { strip } from "@/utils";
 
 export type HeaderProps = FlexProps<"header">;
 

--- a/src/components/Hidden/Hidden.tsx
+++ b/src/components/Hidden/Hidden.tsx
@@ -1,8 +1,8 @@
 import { forwardRef } from "react";
 // Components
-import Box, { BoxProps } from "../Box/Box";
+import Box, { BoxProps } from "@components/Box";
 // Utils
-import { strip } from "../../utils";
+import { strip } from "@/utils";
 
 export type HiddenProps = BoxProps;
 

--- a/src/components/Hide/Hide.tsx
+++ b/src/components/Hide/Hide.tsx
@@ -1,12 +1,12 @@
 import { forwardRef } from "react";
 // Components
-import Box, { BoxProps } from "../Box/Box";
+import Box, { BoxProps } from "@components/Box";
 // Hooks
-import useMediaQuery from "../../hooks/useMediaQuery/useMediaQuery";
+import useMediaQuery from "@hooks/useMediaQuery";
 // Types
-import { PrismaneBreakpoints, PrismaneProps } from "../../types";
+import { PrismaneBreakpoints, PrismaneProps } from "@/types";
 // Utils
-import { strip, dual, fr } from "../../utils";
+import { strip, dual, fr } from "@/utils";
 
 export type HideProps = PrismaneProps<
   {

--- a/src/components/Highlight/Highlight.tsx
+++ b/src/components/Highlight/Highlight.tsx
@@ -1,14 +1,10 @@
 import { forwardRef } from "react";
 // Components
-import Box, { BoxProps } from "../Box/Box";
+import Box, { BoxProps } from "@components/Box";
 // Types
-import {
-  Versatile,
-  PrismaneVersatile,
-  PrismaneVersatileRef,
-} from "../../types";
+import { Versatile, PrismaneVersatile, PrismaneVersatileRef } from "@/types";
 // Utils
-import { strip, fr } from "../../utils";
+import { strip, fr } from "@/utils";
 
 export type HighlightProps<E extends Versatile = "mark"> = PrismaneVersatile<
   E,

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -1,10 +1,10 @@
 import { forwardRef } from "react";
 // Components
-import Square, { SquareProps } from "../Square/Square";
+import Square, { SquareProps } from "@components/Square";
 // Types
-import { PrismaneBreakpoints, PrismaneProps } from "../../types";
+import { PrismaneBreakpoints, PrismaneProps } from "@/types";
 // Utils
-import { strip, dual, fr } from "../../utils";
+import { strip, dual, fr } from "@/utils";
 
 export type IconProps = PrismaneProps<
   {

--- a/src/components/Image/Image.tsx
+++ b/src/components/Image/Image.tsx
@@ -1,10 +1,10 @@
 import { forwardRef } from "react";
 // Components
-import Box, { BoxProps } from "../Box/Box";
+import Box, { BoxProps } from "@components/Box";
 // Types
-import { PrismaneProps } from "../../types";
+import { PrismaneProps } from "@/types";
 // Utils
-import { strip } from "../../utils";
+import { strip } from "@/utils";
 
 export type ImageProps = PrismaneProps<
   {

--- a/src/components/Key/Key.tsx
+++ b/src/components/Key/Key.tsx
@@ -1,8 +1,8 @@
 import { forwardRef } from "react";
 // Components
-import Box, { BoxProps } from "../Box/Box";
+import Box, { BoxProps } from "@components/Box";
 // Utils
-import { strip, fr } from "../../utils";
+import { strip, fr } from "@/utils";
 
 export type KeyProps = BoxProps<"kbd">;
 

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -1,15 +1,15 @@
 import { forwardRef } from "react";
 // Components
-import Text, { TextProps } from "../Text/Text";
+import Text, { TextProps } from "@components/Text";
 // Types
 import {
   Versatile,
   PrismaneVersatile,
   PrismaneVersatileRef,
   PrismaneProps,
-} from "../../types";
+} from "@/types";
 // Utils
-import { strip, variants, fr } from "../../utils";
+import { strip, variants, fr } from "@/utils";
 
 export type LinkProps<E extends Versatile = "a"> = PrismaneVersatile<
   E,

--- a/src/components/List/List.tsx
+++ b/src/components/List/List.tsx
@@ -1,23 +1,21 @@
 import { forwardRef } from "react";
 // Components
-import Flex, { FlexProps } from "../Flex/Flex";
+import Flex, { FlexProps } from "@components/Flex";
 // Types
 import {
   PrismaneWithInternal,
   Versatile,
   PrismaneVersatile,
   PrismaneVersatileRef,
-} from "../../types";
+} from "@/types";
 // Utils
-import { strip } from "../../utils";
+import { strip } from "@/utils";
 
 // Internal Components
-import ListUnordered, {
-  ListUnorderedProps,
-} from "./ListUnordered/ListUnordered";
-import ListOrdered, { ListOrderedProps } from "./ListOrdered/ListOrdered";
-import ListItem, { ListItemProps } from "./ListItem/ListItem";
-import ListIcon, { ListIconProps } from "./ListIcon/ListIcon";
+import ListUnordered, { ListUnorderedProps } from "./ListUnordered";
+import ListOrdered, { ListOrderedProps } from "./ListOrdered";
+import ListItem, { ListItemProps } from "./ListItem";
+import ListIcon, { ListIconProps } from "./ListIcon";
 
 export {
   type ListUnorderedProps,

--- a/src/components/List/ListIcon/ListIcon.tsx
+++ b/src/components/List/ListIcon/ListIcon.tsx
@@ -1,8 +1,8 @@
 import { forwardRef } from "react";
 // Components
-import Icon, { IconProps } from "../../Icon/Icon";
+import Icon, { IconProps } from "@components/Icon";
 // Utils
-import { strip } from "../../../utils";
+import { strip } from "@/utils";
 
 export type ListIconProps = IconProps;
 

--- a/src/components/List/ListIcon/index.ts
+++ b/src/components/List/ListIcon/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./ListIcon";
+export { default, type ListIconProps } from "./ListIcon";

--- a/src/components/List/ListItem/ListItem.tsx
+++ b/src/components/List/ListItem/ListItem.tsx
@@ -1,9 +1,9 @@
 import { forwardRef } from "react";
 // Components
-import Flex, { FlexProps } from "../../Flex/Flex";
-import Box from "../../Box/Box";
+import Flex, { FlexProps } from "@components/Flex";
+import Box from "@components/Box";
 // Utils
-import { strip, fr } from "../../../utils";
+import { strip, fr } from "@/utils";
 
 export type ListItemProps = FlexProps<"li">;
 

--- a/src/components/List/ListItem/index.ts
+++ b/src/components/List/ListItem/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./ListItem";
+export { default, type ListItemProps } from "./ListItem";

--- a/src/components/List/ListOrdered/ListOrdered.tsx
+++ b/src/components/List/ListOrdered/ListOrdered.tsx
@@ -1,8 +1,8 @@
 import { forwardRef } from "react";
 // Components
-import List, { ListProps } from "../../List/List";
+import List, { ListProps } from "@components/List";
 // Utils
-import { strip } from "../../../utils";
+import { strip } from "@/utils";
 
 export type ListOrderedProps = ListProps<"ol">;
 

--- a/src/components/List/ListOrdered/index.ts
+++ b/src/components/List/ListOrdered/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./ListOrdered";
+export { default, type ListOrderedProps } from "./ListOrdered";

--- a/src/components/List/ListUnordered/ListUnordered.tsx
+++ b/src/components/List/ListUnordered/ListUnordered.tsx
@@ -1,8 +1,8 @@
 import { forwardRef } from "react";
 // Components
-import List, { ListProps } from "../../List/List";
+import List, { ListProps } from "@components/List";
 // Utils
-import { strip } from "../../../utils";
+import { strip } from "@/utils";
 
 export type ListUnorderedProps = ListProps;
 

--- a/src/components/List/ListUnordered/index.ts
+++ b/src/components/List/ListUnordered/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./ListUnordered";
+export { default, type ListUnorderedProps } from "./ListUnordered";

--- a/src/components/Main/Main.tsx
+++ b/src/components/Main/Main.tsx
@@ -1,8 +1,8 @@
 import { forwardRef } from "react";
 // Components
-import Flex, { FlexProps } from "../Flex/Flex";
+import Flex, { FlexProps } from "@components/Flex";
 // Utils
-import { strip, fr } from "../../utils";
+import { strip, fr } from "@/utils";
 
 export type MainProps = FlexProps<"main">;
 

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -1,19 +1,19 @@
 import { forwardRef } from "react";
 // Components
-import Paper, { PaperProps } from "../Paper/Paper";
-import Animation, { AnimationProps } from "../Animation/Animation";
+import Paper, { PaperProps } from "@components/Paper";
+import Animation, { AnimationProps } from "@components/Animation";
 // Hooks
-import usePresence from "../../hooks/usePresence";
-import useAnimation from "../../hooks/useAnimation";
+import usePresence from "@hooks/usePresence";
+import useAnimation from "@hooks/useAnimation";
 // Types
-import { PrismaneProps, PrismaneWithInternal } from "../../types";
+import { PrismaneProps, PrismaneWithInternal } from "@/types";
 // Utils
-import { strip, fr } from "../../utils";
+import { strip, fr } from "@/utils";
 
 // Internal Components
-import MenuItem, { MenuItemProps } from "./MenuItem/MenuItem";
-import MenuLabel, { MenuLabelProps } from "./MenuLabel/MenuLabel";
-import MenuIcon, { MenuIconProps } from "./MenuIcon/MenuIcon";
+import MenuItem, { MenuItemProps } from "./MenuItem";
+import MenuLabel, { MenuLabelProps } from "./MenuLabel";
+import MenuIcon, { MenuIconProps } from "./MenuIcon";
 
 export { type MenuItemProps, type MenuLabelProps, type MenuIconProps };
 

--- a/src/components/Menu/MenuIcon/MenuIcon.tsx
+++ b/src/components/Menu/MenuIcon/MenuIcon.tsx
@@ -1,8 +1,8 @@
 import { forwardRef } from "react";
 // Components
-import Icon, { IconProps } from "../../Icon/Icon";
+import Icon, { IconProps } from "@components/Icon";
 // Utils
-import { strip } from "../../../utils";
+import { strip } from "@/utils";
 
 export type MenuIconProps = Omit<IconProps, "size">;
 

--- a/src/components/Menu/MenuIcon/index.ts
+++ b/src/components/Menu/MenuIcon/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./MenuIcon";
+export { default, type MenuIconProps } from "./MenuIcon";

--- a/src/components/Menu/MenuItem/MenuItem.tsx
+++ b/src/components/Menu/MenuItem/MenuItem.tsx
@@ -1,11 +1,11 @@
 import { forwardRef } from "react";
 // Components
-import Flex, { FlexProps } from "../../Flex/Flex";
-import Transition, { TransitionProps } from "../../Transition/Transition";
+import Flex, { FlexProps } from "@components/Flex";
+import Transition, { TransitionProps } from "@components/Transition";
 // Utils
-import { strip, fr } from "../../../utils";
+import { strip, fr } from "@/utils";
 // Types
-import { PrismaneColors, PrismaneProps } from "../../../types";
+import { PrismaneColors, PrismaneProps } from "@/types";
 
 export type MenuItemProps = PrismaneProps<
   {

--- a/src/components/Menu/MenuItem/index.ts
+++ b/src/components/Menu/MenuItem/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./MenuItem";
+export { default, type MenuItemProps } from "./MenuItem";

--- a/src/components/Menu/MenuLabel/MenuLabel.tsx
+++ b/src/components/Menu/MenuLabel/MenuLabel.tsx
@@ -1,10 +1,10 @@
 import { forwardRef } from "react";
 // Components
-import Flex, { FlexProps } from "../../Flex/Flex";
+import Flex, { FlexProps } from "@components/Flex";
 // Utils
-import { strip, fr } from "../../../utils";
+import { strip, fr } from "@/utils";
 // Types
-import { PrismaneColors, PrismaneProps } from "../../../types";
+import { PrismaneColors, PrismaneProps } from "@/types";
 
 export type MenuLabelProps = PrismaneProps<
   { color?: PrismaneColors },

--- a/src/components/Menu/MenuLabel/index.ts
+++ b/src/components/Menu/MenuLabel/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./MenuLabel";
+export { default, type MenuLabelProps } from "./MenuLabel";

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -1,23 +1,23 @@
 import { forwardRef, useEffect } from "react";
 // Components
-import Paper, { PaperProps } from "../Paper/Paper";
-import Animation, { AnimationProps } from "../Animation/Animation";
-import Backdrop from "../Backdrop/Backdrop";
-import Portal from "../Portal/Portal";
+import Paper, { PaperProps } from "@components/Paper";
+import Animation, { AnimationProps } from "@components/Animation";
+import Backdrop from "@components/Backdrop";
+import Portal from "@components/Portal";
 // Hooks
-import useAnimation from "../../hooks/useAnimation";
-import usePresence from "../../hooks/usePresence";
-import useKeyboardShortcut from "../../hooks/useKeyboardShortcut";
+import useAnimation from "@hooks/useAnimation";
+import usePresence from "@hooks/usePresence";
+import useKeyboardShortcut from "@hooks/useKeyboardShortcut";
 // Context
 import { ModalContextProvider } from "./ModalContext";
 // Types
-import { PrismaneProps, PrismaneWithInternal } from "../../types";
+import { PrismaneProps, PrismaneWithInternal } from "@/types";
 // Utils
-import { strip, fr } from "../../utils";
+import { strip, fr } from "@/utils";
 
 // Internal Components
-import ModalHeader, { ModalHeaderProps } from "./ModalHeader/ModalHeader";
-import ModalFooter, { ModalFooterProps } from "./ModalFooter/ModalFooter";
+import ModalHeader, { ModalHeaderProps } from "./ModalHeader";
+import ModalFooter, { ModalFooterProps } from "./ModalFooter";
 
 export { type ModalHeaderProps, type ModalFooterProps };
 

--- a/src/components/Modal/ModalFooter/ModalFooter.tsx
+++ b/src/components/Modal/ModalFooter/ModalFooter.tsx
@@ -1,8 +1,8 @@
 import { forwardRef } from "react";
 // Components
-import Flex, { FlexProps } from "../../Flex/Flex";
+import Flex, { FlexProps } from "@components/Flex";
 // Utils
-import { strip, fr } from "../../../utils";
+import { strip, fr } from "@/utils";
 
 export type ModalFooterProps = FlexProps;
 

--- a/src/components/Modal/ModalFooter/index.ts
+++ b/src/components/Modal/ModalFooter/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./ModalFooter";
+export { default, type ModalFooterProps } from "./ModalFooter";

--- a/src/components/Modal/ModalHeader/ModalHeader.tsx
+++ b/src/components/Modal/ModalHeader/ModalHeader.tsx
@@ -1,11 +1,11 @@
 import { forwardRef } from "react";
 // Components
-import Flex, { FlexProps } from "../../Flex/Flex";
-import CloseButton from "../../CloseButton/CloseButton";
+import Flex, { FlexProps } from "@components/Flex";
+import CloseButton from "@components/CloseButton";
 // Context
 import { useModalContext } from "../ModalContext";
 // Utils
-import { strip, fr } from "../../../utils";
+import { strip, fr } from "@/utils";
 
 export type ModalHeaderProps = FlexProps;
 

--- a/src/components/Modal/ModalHeader/index.ts
+++ b/src/components/Modal/ModalHeader/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./ModalHeader";
+export { default, type ModalHeaderProps } from "./ModalHeader";

--- a/src/components/NativeDateField/NativeDateField.tsx
+++ b/src/components/NativeDateField/NativeDateField.tsx
@@ -1,10 +1,8 @@
 import { forwardRef } from "react";
 // Components
-import Field, { FieldProps } from "../Field/Field";
-// Hooks
-import { useFieldProps } from "../Field";
+import Field, { FieldProps, useFieldProps } from "@components/Field";
 // Utils
-import { strip } from "../../utils";
+import { strip } from "@/utils";
 
 export type NativeDateFieldProps = FieldProps;
 

--- a/src/components/NativeSelectField/NativeSelectField.tsx
+++ b/src/components/NativeSelectField/NativeSelectField.tsx
@@ -1,13 +1,11 @@
 import { forwardRef } from "react";
 // Components
-import Field, { FieldProps } from "../Field/Field";
-import Text from "../Text/Text";
-// Hooks
-import { useFieldProps } from "../Field";
+import Field, { FieldProps, useFieldProps } from "@components/Field";
+import Text from "@components/Text";
 // Types
-import { PrismaneProps } from "../../types";
+import { PrismaneProps } from "@/types";
 // Utils
-import { strip } from "../../utils";
+import { strip } from "@/utils";
 
 export type NativeSelectFieldProps = PrismaneProps<
   {

--- a/src/components/NumberField/NumberField.tsx
+++ b/src/components/NumberField/NumberField.tsx
@@ -1,16 +1,15 @@
 import { forwardRef, useRef } from "react";
 import { CaretUp, CaretDown } from "@phosphor-icons/react";
 // Components
-import Field, { FieldProps } from "../Field/Field";
-import Flex from "../Flex/Flex";
-import Transition from "../Transition/Transition";
+import Field, { FieldProps, useFieldProps } from "@components/Field";
+import Flex from "@components/Flex";
+import Transition from "@components/Transition";
 // Hooks
-import { useFieldProps } from "../Field";
-import useEmulatedFieldChange from "../../hooks/useEmulatedFieldChange";
+import useEmulatedFieldChange from "@hooks/useEmulatedFieldChange";
 // Types
-import { PrismaneProps } from "../../types";
+import { PrismaneProps } from "@/types";
 // Utils
-import { strip, fr } from "../../utils";
+import { strip, fr } from "@/utils";
 
 export type NumberFieldProps = PrismaneProps<
   {

--- a/src/components/Paper/Paper.tsx
+++ b/src/components/Paper/Paper.tsx
@@ -1,15 +1,15 @@
 import { forwardRef } from "react";
 // Components
-import Flex, { FlexProps } from "../Flex/Flex";
+import Flex, { FlexProps } from "@components/Flex";
 // Types
 import {
   Versatile,
   PrismaneVersatile,
   PrismaneVersatileRef,
   PrismaneProps,
-} from "../../types";
+} from "@/types";
 // Utils
-import { strip } from "../../utils";
+import { strip } from "@/utils";
 
 export type PaperProps<E extends Versatile = "div"> = PrismaneVersatile<
   E,

--- a/src/components/PasswordField/PasswordField.tsx
+++ b/src/components/PasswordField/PasswordField.tsx
@@ -1,13 +1,11 @@
 import { useState, forwardRef } from "react";
 import { Eye, EyeClosed } from "@phosphor-icons/react";
 // Components
-import Field, { FieldProps } from "../Field/Field";
-import Icon from "../Icon/Icon";
-import Transition from "../Transition/Transition";
-// Hooks
-import { useFieldProps } from "../Field";
+import Field, { FieldProps, useFieldProps } from "@components/Field";
+import Icon from "@components/Icon";
+import Transition from "@components/Transition";
 // Utils
-import { variants, fr } from "../../utils";
+import { variants, fr } from "@/utils";
 
 export type PasswordFieldProps = FieldProps;
 

--- a/src/components/PinField/PinField.tsx
+++ b/src/components/PinField/PinField.tsx
@@ -1,15 +1,14 @@
 import { forwardRef, useState, useRef } from "react";
 // Components
-import Field, { FieldProps } from "../Field/Field";
-import Flex from "../Flex/Flex";
-import Hidden from "../Hidden/Hidden";
+import Field, { FieldProps, useFieldProps } from "@components/Field";
+import Flex from "@components/Flex";
+import Hidden from "@components/Hidden";
 // Hooks
-import { useFieldProps } from "../Field";
-import useEmulatedFieldChange from "../../hooks/useEmulatedFieldChange";
+import useEmulatedFieldChange from "@hooks/useEmulatedFieldChange";
 // Types
-import { PrismaneProps } from "../../types";
+import { PrismaneProps } from "@/types";
 // Utils
-import { fr } from "../../utils";
+import { fr } from "@/utils";
 
 export type PinFieldProps = PrismaneProps<
   {
@@ -24,14 +23,7 @@ const PinField = forwardRef<
   PinFieldProps
 >(
   (
-    {
-      length = 4,
-      masked = false,
-      label,
-      error,
-      size = "base",
-      ...props
-    },
+    { length = 4, masked = false, label, error, size = "base", ...props },
     ref
   ) => {
     const [rest, field] = useFieldProps(props);

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -1,25 +1,23 @@
 import { useState, forwardRef, useRef } from "react";
 // Components
-import Paper, { PaperProps } from "../Paper/Paper";
-import Box from "../Box/Box";
+import Paper, { PaperProps } from "@components/Paper";
+import Box from "@components/Box";
 // Context
 import { PopoverContextProvider } from "./PopoverContext";
 // Hooks
-import useOutsideClick from "../../hooks/useOutsideClick";
+import useOutsideClick from "@hooks/useOutsideClick";
 // Types
 import {
   PrismanePositions,
   PrismaneProps,
   PrismaneWithInternal,
-} from "../../types";
+} from "@/types";
 // Utils
-import { strip } from "../../utils";
+import { strip } from "@/utils";
 
 // Internal Components
-import PopoverControl, {
-  PopoverControlProps,
-} from "./PopoverControl/PopoverControl";
-import PopoverPanel, { PopoverPanelProps } from "./PopoverPanel/PopoverPanel";
+import PopoverControl, { PopoverControlProps } from "./PopoverControl";
+import PopoverPanel, { PopoverPanelProps } from "./PopoverPanel";
 
 export { type PopoverControlProps, type PopoverPanelProps };
 

--- a/src/components/Popover/PopoverContext.ts
+++ b/src/components/Popover/PopoverContext.ts
@@ -1,6 +1,6 @@
 import { createContext, useContext, Dispatch } from "react";
 // Types
-import { PrismanePositions } from "../../types";
+import { PrismanePositions } from "@/types";
 
 export interface PopoverContextValue {
   open: boolean;

--- a/src/components/Popover/PopoverControl/PopoverControl.tsx
+++ b/src/components/Popover/PopoverControl/PopoverControl.tsx
@@ -1,10 +1,10 @@
 import { forwardRef } from "react";
 // Components
-import Flex, { FlexProps } from "../../Flex/Flex";
+import Flex, { FlexProps } from "@components/Flex";
 // Context
 import { usePopoverContext } from "../PopoverContext";
 // Utils
-import { strip } from "../../../utils";
+import { strip } from "@/utils";
 
 export type PopoverControlProps = FlexProps;
 

--- a/src/components/Popover/PopoverControl/index.ts
+++ b/src/components/Popover/PopoverControl/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./PopoverControl";
+export { default, type PopoverControlProps } from "./PopoverControl";

--- a/src/components/Popover/PopoverPanel/PopoverPanel.tsx
+++ b/src/components/Popover/PopoverPanel/PopoverPanel.tsx
@@ -1,15 +1,15 @@
 import { forwardRef } from "react";
 // Components
-import Paper, { PaperProps } from "../../Paper/Paper";
-import Animation, { AnimationProps } from "../../Animation/Animation";
+import Paper, { PaperProps } from "@components/Paper";
+import Animation, { AnimationProps } from "@components/Animation";
 // Context
 import { usePopoverContext } from "../PopoverContext";
 // Hooks
-import useAnimation from "../../../hooks/useAnimation";
-import usePresence from "../../../hooks/usePresence";
+import useAnimation from "@hooks/useAnimation";
+import usePresence from "@hooks/usePresence";
 
 // Utils
-import { strip, variants, fr } from "../../../utils";
+import { strip, variants, fr } from "@/utils";
 
 export type PopoverPanelProps = AnimationProps & PaperProps;
 

--- a/src/components/Popover/PopoverPanel/index.ts
+++ b/src/components/Popover/PopoverPanel/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./PopoverPanel";
+export { default, type PopoverPanelProps } from "./PopoverPanel";

--- a/src/components/Portal/Portal.tsx
+++ b/src/components/Portal/Portal.tsx
@@ -1,11 +1,11 @@
 import { forwardRef, useState, useEffect } from "react";
 import ReactDOM from "react-dom";
 // Components
-import Box, { BoxProps } from "../Box/Box";
+import Box, { BoxProps } from "@components/Box";
 // Types
-import { PrismaneProps } from "../../types";
+import { PrismaneProps } from "@/types";
 // Utils
-import { strip } from "../../utils";
+import { strip } from "@/utils";
 
 export type PortalProps = PrismaneProps<
   {

--- a/src/components/PrismaneProvider/PrismaneContext.ts
+++ b/src/components/PrismaneProvider/PrismaneContext.ts
@@ -1,8 +1,8 @@
 import { Dispatch, createContext, useContext } from "react";
 // Themes
-import { base } from "../../themes/base";
+import { base } from "@themes/base";
 // Types
-import { PrismaneTheme } from "../../types";
+import { PrismaneTheme } from "@/types";
 
 export interface PrismaneContextValue {
   theme: PrismaneTheme;

--- a/src/components/PrismaneProvider/PrismaneProvider.tsx
+++ b/src/components/PrismaneProvider/PrismaneProvider.tsx
@@ -1,13 +1,13 @@
 import { ReactNode, FC, useState, useEffect } from "react";
-import { getCssText } from "../../../stitches.config";
-import styles from "../../index.css";
+import { getCssText } from "@/../stitches.config";
+import styles from "@/index.css";
 // Context
 import { PrismaneContextProvider } from "./PrismaneContext";
 // Themes
-import { base } from "../../themes/base";
-import { createTheme, applyTheme } from "../../themes/theme";
+import { base } from "@themes/base";
+import { createTheme, applyTheme } from "@themes/theme";
 // Types
-import { PrismaneInputTheme } from "../../types";
+import { PrismaneInputTheme } from "@/types";
 // Font
 import "@fontsource/poppins/100.css";
 import "@fontsource/poppins/200.css";

--- a/src/components/PrismaneProvider/usePrismaneColor/usePrismaneColor.ts
+++ b/src/components/PrismaneProvider/usePrismaneColor/usePrismaneColor.ts
@@ -1,17 +1,17 @@
 import { useState, useEffect } from "react";
 // Theme
-import { transformColor } from "../../../themes/theme";
+import { transformColor } from "@themes/theme";
 import { usePrismaneTheme } from "../PrismaneContext";
 // Globals
 import {
   PRISMANE_COLORS,
   PRISMANE_COLORS_MAP,
   PRISMANE_SHADES_MAP,
-} from "../../../constants";
+} from "@/constants";
 // Types
-import { PrismaneColors, PrismaneShades, PrismaneTheme } from "../../../types";
+import { PrismaneColors, PrismaneShades, PrismaneTheme } from "@/types";
 // Utils
-import { parse } from "../../../utils";
+import { parse } from "@/utils";
 
 const usePrismaneColor: any = () => {
   const { theme } = usePrismaneTheme();

--- a/src/components/Progress/Progress.tsx
+++ b/src/components/Progress/Progress.tsx
@@ -1,15 +1,11 @@
 import { forwardRef } from "react";
 // Components
-import Flex, { FlexProps } from "../Flex/Flex";
-import Transition, { TransitionProps } from "../Transition/Transition";
+import Flex, { FlexProps } from "@components/Flex";
+import Transition, { TransitionProps } from "@components/Transition";
 // Types
-import {
-  PrismaneBreakpoints,
-  PrismaneProps,
-  PrismaneStyles,
-} from "../../types";
+import { PrismaneBreakpoints, PrismaneProps, PrismaneStyles } from "@/types";
 // Utils
-import { strip, fr, dual } from "../../utils";
+import { strip, fr, dual } from "@/utils";
 
 export type ProgressProps = PrismaneProps<
   {

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -1,22 +1,21 @@
 import { forwardRef } from "react";
 // Components
-import Animation from "../Animation";
-import Field from "../Field/Field";
-import Flex, { FlexProps } from "../Flex/Flex";
-import Transition, { TransitionProps } from "../Transition/Transition";
-import Hidden from "../Hidden/Hidden";
+import Animation from "@components/Animation";
+import Field, { useFieldProps } from "@components/Field";
+import Flex, { FlexProps } from "@components/Flex";
+import Transition, { TransitionProps } from "@components/Transition";
+import Hidden from "@components/Hidden";
 // Context
 import { useRadioContext } from "./RadioContext";
-// Types
-import { PrismaneFieldComponent, PrismaneWithInternal } from "../../types";
 // Hooks
-import { useFieldProps } from "../Field";
-import useId from "../../hooks/useId";
+import useId from "@hooks/useId";
+// Types
+import { PrismaneFieldComponent, PrismaneWithInternal } from "@/types";
 // Utils
-import { strip, variants, fr } from "../../utils";
+import { strip, variants, fr } from "@/utils";
 
 // Internal Components
-import RadioGroup, { RadioGroupProps } from "./RadioGroup/RadioGroup";
+import RadioGroup, { RadioGroupProps } from "./RadioGroup";
 
 export { type RadioGroupProps };
 

--- a/src/components/Radio/RadioContext.ts
+++ b/src/components/Radio/RadioContext.ts
@@ -1,5 +1,5 @@
 import { createContext, useContext } from "react";
-import { PrismaneFieldComponent } from "../../types";
+import { PrismaneFieldComponent } from "@/types";
 
 export type RadioContextValue = PrismaneFieldComponent;
 

--- a/src/components/Radio/RadioGroup/RadioGroup.tsx
+++ b/src/components/Radio/RadioGroup/RadioGroup.tsx
@@ -1,14 +1,14 @@
 import { forwardRef } from "react";
 // Components
-import Stack from "../../Stack";
-import Field, { useFieldProps } from "../../Field";
-import Flex, { FlexProps } from "../../Flex/Flex";
+import Stack from "@components/Stack";
+import Field, { useFieldProps } from "@components/Field";
+import Flex, { FlexProps } from "@components/Flex";
 // Context
 import { RadioContextProvider } from "../RadioContext";
 // Types
-import { PrismaneFieldComponent } from "../../../types";
+import { PrismaneFieldComponent } from "@/types";
 // Utils
-import { strip, fr } from "../../../utils";
+import { strip, fr } from "@/utils";
 
 export type RadioGroupProps = PrismaneFieldComponent & FlexProps;
 

--- a/src/components/Radio/RadioGroup/index.ts
+++ b/src/components/Radio/RadioGroup/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./RadioGroup";
+export { default, type RadioGroupProps } from "./RadioGroup";

--- a/src/components/SegmentedField/SegmentedField.tsx
+++ b/src/components/SegmentedField/SegmentedField.tsx
@@ -1,16 +1,15 @@
 import { ReactNode, forwardRef, useRef } from "react";
 // Components
-import Field, { FieldProps } from "../Field/Field";
-import Transition from "../Transition/Transition";
-import Flex from "../Flex/Flex";
-import Text from "../Text/Text";
+import Field, { FieldProps, useFieldProps } from "@components/Field";
+import Transition from "@components/Transition";
+import Flex from "@components/Flex";
+import Text from "@components/Text";
 // Hooks
-import { useFieldProps } from "../Field";
-import useEmulatedFieldChange from "../../hooks/useEmulatedFieldChange";
+import useEmulatedFieldChange from "@hooks/useEmulatedFieldChange";
 // Types
-import { PrismaneProps } from "../../types";
+import { PrismaneProps } from "@/types";
 // Utils
-import { variants, fr } from "../../utils";
+import { variants, fr } from "@/utils";
 
 export type SegmentedFieldProps = PrismaneProps<
   {

--- a/src/components/SelectField/SelectField.tsx
+++ b/src/components/SelectField/SelectField.tsx
@@ -1,19 +1,18 @@
 import { forwardRef, useState, useRef, ReactNode } from "react";
 import { CaretUpDown } from "@phosphor-icons/react";
 // Components
-import Field, { FieldProps } from "../Field/Field";
-import Menu from "../Menu/Menu";
-import Icon from "../Icon/Icon";
-import Flex from "../Flex/Flex";
+import Field, { FieldProps, useFieldProps } from "@components/Field";
+import Menu from "@components/Menu";
+import Icon from "@components/Icon";
+import Flex from "@components/Flex";
 // Hooks
-import { useFieldProps } from "../Field";
-import useKeyboardShortcut from "../../hooks/useKeyboardShortcut";
-import useEmulatedFieldChange from "../../hooks/useEmulatedFieldChange";
-import useOutsideClick from "../../hooks/useOutsideClick";
+import useKeyboardShortcut from "@hooks/useKeyboardShortcut";
+import useEmulatedFieldChange from "@hooks/useEmulatedFieldChange";
+import useOutsideClick from "@hooks/useOutsideClick";
 // Types
-import { PrismaneProps } from "../../types";
+import { PrismaneProps } from "@/types";
 // Utils
-import { strip, variants, fr } from "../../utils";
+import { strip, variants, fr } from "@/utils";
 
 export type SelectFieldProps = PrismaneProps<
   {

--- a/src/components/Show/Show.tsx
+++ b/src/components/Show/Show.tsx
@@ -1,12 +1,12 @@
 import { forwardRef } from "react";
 // Components
-import Box, { BoxProps } from "../Box/Box";
+import Box, { BoxProps } from "@components/Box";
 // Hooks
-import useMediaQuery from "../../hooks/useMediaQuery/useMediaQuery";
+import useMediaQuery from "@hooks/useMediaQuery/useMediaQuery";
 // Types
-import { PrismaneBreakpoints, PrismaneProps } from "../../types";
+import { PrismaneBreakpoints, PrismaneProps } from "@/types";
 // Utils
-import { strip, dual, fr } from "../../utils";
+import { strip, dual, fr } from "@/utils";
 
 export type ShowProps = PrismaneProps<
   {

--- a/src/components/Skeleton/Skeleton.tsx
+++ b/src/components/Skeleton/Skeleton.tsx
@@ -1,8 +1,8 @@
 import { forwardRef } from "react";
 // Components
-import Flex, { FlexProps } from "../Flex/Flex";
+import Flex, { FlexProps } from "@components/Flex";
 // Utils
-import { strip, fr, variants } from "../../utils";
+import { strip, fr, variants } from "@/utils";
 
 export type SkeletonProps = {
   variant?: "circular" | "rounded" | "rectangular";

--- a/src/components/Spinner/Spinner.tsx
+++ b/src/components/Spinner/Spinner.tsx
@@ -1,9 +1,9 @@
 import { forwardRef } from "react";
 import { CircleNotch } from "@phosphor-icons/react";
 // Components
-import Icon, { IconProps } from "../Icon/Icon";
+import Icon, { IconProps } from "@components/Icon";
 // Utils
-import { strip } from "../../utils";
+import { strip } from "@/utils";
 
 export type SpinnerProps = IconProps;
 

--- a/src/components/Square/Square.tsx
+++ b/src/components/Square/Square.tsx
@@ -1,6 +1,6 @@
 import { forwardRef } from "react";
 // Components
-import Center, { CenterProps } from "../Center/Center";
+import Center, { CenterProps } from "@components/Center";
 // Types
 import {
   PrismaneStyles,
@@ -8,9 +8,9 @@ import {
   PrismaneVersatile,
   PrismaneVersatileRef,
   PrismaneProps,
-} from "../../types";
+} from "@/types";
 // Utils
-import { strip } from "../../utils";
+import { strip } from "@/utils";
 
 export type SquareProps<E extends Versatile = "div"> = PrismaneVersatile<
   E,

--- a/src/components/Stack/Stack.tsx
+++ b/src/components/Stack/Stack.tsx
@@ -1,8 +1,8 @@
 import { forwardRef } from "react";
 // Components
-import Flex, { FlexProps } from "../Flex/Flex";
+import Flex, { FlexProps } from "@components/Flex";
 // Utils
-import { strip, fr } from "../../utils";
+import { strip, fr } from "@/utils";
 
 export type StackProps = FlexProps;
 

--- a/src/components/Switch/Switch.tsx
+++ b/src/components/Switch/Switch.tsx
@@ -1,16 +1,14 @@
 import { forwardRef } from "react";
 // Components
-import Animation from "../Animation/Animation";
-import Flex, { FlexProps } from "../Flex/Flex";
-import Transition, { TransitionProps } from "../Transition/Transition";
-import Field from "../Field/Field";
-import Hidden from "../Hidden/Hidden";
-// Hooks
-import { useFieldProps } from "../Field";
+import Animation from "@components/Animation";
+import Flex, { FlexProps } from "@components/Flex";
+import Transition, { TransitionProps } from "@components/Transition";
+import Field, { useFieldProps } from "@components/Field";
+import Hidden from "@components/Hidden";
 // Types
-import { PrismaneFieldComponent } from "../../types";
+import { PrismaneFieldComponent } from "@/types";
 // Utils
-import { strip, variants, fr } from "../../utils";
+import { strip, variants, fr } from "@/utils";
 
 export type SwitchProps = PrismaneFieldComponent & FlexProps & TransitionProps;
 

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -1,18 +1,18 @@
 import { forwardRef } from "react";
 // Components
-import Box, { BoxProps } from "../Box/Box";
+import Box, { BoxProps } from "@components/Box";
 // Types
-import { PrismaneWithInternal } from "../../types";
+import { PrismaneWithInternal } from "@/types";
 // Utils
-import { strip } from "../../utils";
+import { strip } from "@/utils";
 
 // Internal Components
-import TableRow, { TableRowProps } from "./TableRow/TableRow";
-import TableHead, { TableHeadProps } from "./TableHead/TableHead";
-import TableFoot, { TableFootProps } from "./TableFoot/TableFoot";
-import TableCell, { TableCellProps } from "./TableCell/TableCell";
-import TableBody, { TableBodyProps } from "./TableBody/TableBody";
-import TableCaption, { TableCaptionProps } from "./TableCaption/TableCaption";
+import TableRow, { TableRowProps } from "./TableRow";
+import TableHead, { TableHeadProps } from "./TableHead";
+import TableFoot, { TableFootProps } from "./TableFoot";
+import TableCell, { TableCellProps } from "./TableCell";
+import TableBody, { TableBodyProps } from "./TableBody";
+import TableCaption, { TableCaptionProps } from "./TableCaption";
 
 export {
   type TableRowProps,

--- a/src/components/Table/TableBody/TableBody.tsx
+++ b/src/components/Table/TableBody/TableBody.tsx
@@ -1,8 +1,8 @@
 import { forwardRef } from "react";
 // Components
-import Box, { BoxProps } from "../../Box/Box";
+import Box, { BoxProps } from "@components/Box";
 // Utils
-import { strip } from "../../../utils";
+import { strip } from "@/utils";
 
 export type TableBodyProps = BoxProps<"tbody">;
 

--- a/src/components/Table/TableBody/index.ts
+++ b/src/components/Table/TableBody/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./TableBody";
+export { default, type TableBodyProps } from "./TableBody";

--- a/src/components/Table/TableCaption/TableCaption.tsx
+++ b/src/components/Table/TableCaption/TableCaption.tsx
@@ -1,10 +1,10 @@
 import { forwardRef } from "react";
 // Components
-import Box, { BoxProps } from "../../Box/Box";
+import Box, { BoxProps } from "@components/Box";
 // Types
-import { PrismaneProps } from "../../../types";
+import { PrismaneProps } from "@/types";
 // Utils
-import { strip, fr } from "../../../utils";
+import { strip, fr } from "@/utils";
 
 export type TableCaptionProps = PrismaneProps<
   {

--- a/src/components/Table/TableCaption/index.ts
+++ b/src/components/Table/TableCaption/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./TableCaption";
+export { default, type TableCaptionProps } from "./TableCaption";

--- a/src/components/Table/TableCell/TableCell.tsx
+++ b/src/components/Table/TableCell/TableCell.tsx
@@ -1,8 +1,8 @@
 import { forwardRef } from "react";
 // Components
-import Box, { BoxProps } from "../../Box/Box";
+import Box, { BoxProps } from "@components/Box";
 // Utils
-import { strip, fr } from "../../../utils";
+import { strip, fr } from "@/utils";
 
 export type TableCellProps = BoxProps<"td">;
 

--- a/src/components/Table/TableCell/index.ts
+++ b/src/components/Table/TableCell/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./TableCell";
+export { default, type TableCellProps } from "./TableCell";

--- a/src/components/Table/TableFoot/TableFoot.tsx
+++ b/src/components/Table/TableFoot/TableFoot.tsx
@@ -1,8 +1,8 @@
 import { forwardRef } from "react";
 // Components
-import Box, { BoxProps } from "../../Box/Box";
+import Box, { BoxProps } from "@components/Box";
 // Utils
-import { strip } from "../../../utils";
+import { strip } from "@/utils";
 
 export type TableFootProps = BoxProps<"tfoot">;
 

--- a/src/components/Table/TableFoot/index.ts
+++ b/src/components/Table/TableFoot/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./TableFoot";
+export { default, type TableFootProps } from "./TableFoot";

--- a/src/components/Table/TableHead/TableHead.tsx
+++ b/src/components/Table/TableHead/TableHead.tsx
@@ -1,8 +1,8 @@
 import { forwardRef } from "react";
 // Components
-import Box, { BoxProps } from "../../Box/Box";
+import Box, { BoxProps } from "@components/Box";
 // Utils
-import { strip } from "../../../utils";
+import { strip } from "@/utils";
 
 export type TableHeadProps = BoxProps<"thead">;
 

--- a/src/components/Table/TableHead/index.ts
+++ b/src/components/Table/TableHead/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./TableHead";
+export { default, type TableHeadProps } from "./TableHead";

--- a/src/components/Table/TableRow/TableRow.tsx
+++ b/src/components/Table/TableRow/TableRow.tsx
@@ -1,8 +1,8 @@
 import { forwardRef } from "react";
 // Components
-import Box, { BoxProps } from "../../Box/Box";
+import Box, { BoxProps } from "@components/Box";
 // Utils
-import { strip } from "../../../utils";
+import { strip } from "@/utils";
 
 export type TableRowProps = BoxProps<"tr">;
 

--- a/src/components/Table/TableRow/index.ts
+++ b/src/components/Table/TableRow/index.ts
@@ -1,0 +1,1 @@
+export { default, type TableRowProps } from "./TableRow";

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -1,17 +1,17 @@
 import { forwardRef, useState } from "react";
 // Components
-import Flex, { FlexProps } from "../Flex/Flex";
+import Flex, { FlexProps } from "@components/Flex";
 // Context
 import { TabsContextProvider } from "./TabsContext";
 // Types
-import { PrismaneProps, PrismaneWithInternal } from "../../types";
+import { PrismaneProps, PrismaneWithInternal } from "@/types";
 // Utils
-import { strip } from "../../utils";
+import { strip } from "@/utils";
 
 // Internal Components
-import TabsList, { TabsListProps } from "./TabsList/TabsList";
-import TabsPanel, { TabsPanelProps } from "./TabsPanel/TabsPanel";
-import TabsTab, { TabsTabProps } from "./TabsTab/TabsTab";
+import TabsList, { TabsListProps } from "./TabsList";
+import TabsPanel, { TabsPanelProps } from "./TabsPanel";
+import TabsTab, { TabsTabProps } from "./TabsTab";
 
 export { type TabsListProps, type TabsPanelProps, type TabsTabProps };
 

--- a/src/components/Tabs/TabsList/TabsList.tsx
+++ b/src/components/Tabs/TabsList/TabsList.tsx
@@ -1,10 +1,10 @@
 import { forwardRef } from "react";
 // Components
-import Flex, { FlexProps } from "../../Flex/Flex";
+import Flex, { FlexProps } from "@components/Flex";
 // Context
 import { useTabsContext } from "../TabsContext";
 // Utils
-import { strip, fr } from "../../../utils";
+import { strip, fr } from "@/utils";
 
 export type TabsListProps = FlexProps;
 

--- a/src/components/Tabs/TabsList/index.ts
+++ b/src/components/Tabs/TabsList/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./TabsList";
+export { default, type TabsListProps } from "./TabsList";

--- a/src/components/Tabs/TabsPanel/TabsPanel.tsx
+++ b/src/components/Tabs/TabsPanel/TabsPanel.tsx
@@ -1,12 +1,12 @@
 import { forwardRef } from "react";
 // Components
-import Flex, { FlexProps } from "../../Flex/Flex";
+import Flex, { FlexProps } from "@components/Flex";
 // Context
 import { useTabsContext } from "../TabsContext";
 // Types
-import { PrismaneProps } from "../../../types";
+import { PrismaneProps } from "@/types";
 // Utils
-import { strip } from "../../../utils";
+import { strip } from "@/utils";
 
 export type TabsPanelProps = PrismaneProps<{ value: string }, FlexProps>;
 

--- a/src/components/Tabs/TabsPanel/index.ts
+++ b/src/components/Tabs/TabsPanel/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./TabsPanel";
+export { default, type TabsPanelProps } from "./TabsPanel";

--- a/src/components/Tabs/TabsTab/TabsTab.tsx
+++ b/src/components/Tabs/TabsTab/TabsTab.tsx
@@ -1,13 +1,13 @@
 import { forwardRef } from "react";
 // Components
-import Flex, { FlexProps } from "../../Flex/Flex";
-import Transition, { TransitionProps } from "../../Transition/Transition";
+import Flex, { FlexProps } from "@components/Flex";
+import Transition, { TransitionProps } from "@components/Transition";
 // Context
 import { useTabsContext } from "../TabsContext";
 // Types
-import { PrismaneProps } from "../../../types";
+import { PrismaneProps } from "@/types";
 // Utils
-import { strip, variants, fr } from "../../../utils";
+import { strip, variants, fr } from "@/utils";
 
 export type TabsTabProps = PrismaneProps<
   { value: string },

--- a/src/components/Tabs/TabsTab/index.ts
+++ b/src/components/Tabs/TabsTab/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./TabsTab";
+export { default, type TabsTabProps } from "./TabsTab";

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -1,13 +1,9 @@
 import { forwardRef } from "react";
 // Components
-import Box, { BoxProps } from "../Box/Box";
+import Box, { BoxProps } from "@components/Box";
 // Types
-import {
-  Versatile,
-  PrismaneVersatile,
-  PrismaneVersatileRef,
-} from "../../types";
-import { strip } from "../../utils";
+import { Versatile, PrismaneVersatile, PrismaneVersatileRef } from "@/types";
+import { strip } from "@/utils";
 
 export type TextProps<E extends Versatile = "span"> = PrismaneVersatile<
   E,

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -1,12 +1,10 @@
 import { forwardRef } from "react";
 // Components
-import Field, { FieldProps } from "../Field/Field";
-// Hooks
-import { useFieldProps } from "../Field";
+import Field, { FieldProps, useFieldProps } from "@components/Field";
 // Types
-import { PrismaneProps } from "../../types";
+import { PrismaneProps } from "@/types";
 // Utils
-import { strip, fr, variants } from "../../utils";
+import { strip, fr, variants } from "@/utils";
 
 export type TextFieldProps = PrismaneProps<
   {

--- a/src/components/TextareaField/TextareaField.tsx
+++ b/src/components/TextareaField/TextareaField.tsx
@@ -1,10 +1,8 @@
 import { forwardRef } from "react";
 // Components
-import Field, { FieldProps } from "../Field/Field";
-// Hooks
-import { useFieldProps } from "../Field";
+import Field, { FieldProps, useFieldProps } from "@components/Field";
 // Utils
-import { strip, fr, variants } from "../../utils";
+import { strip, fr, variants } from "@/utils";
 
 export type TextareaFieldProps = FieldProps;
 

--- a/src/components/Toaster/Toast/Toast.tsx
+++ b/src/components/Toaster/Toast/Toast.tsx
@@ -1,15 +1,15 @@
 import { forwardRef, useEffect, useState } from "react";
 // Components
-import Flex, { FlexProps } from "../../Flex/Flex";
-import Animation, { AnimationProps } from "../../Animation/Animation";
+import Flex, { FlexProps } from "@components/Flex";
+import Animation, { AnimationProps } from "@components/Animation";
 // Hooks
-import usePresence from "../../../hooks/usePresence";
+import usePresence from "@hooks/usePresence";
 // Context
 import { useToasterContext } from "../ToasterContext";
 // Types
-import { PrismaneProps } from "../../../types";
+import { PrismaneProps } from "@/types";
 // Utils
-import { strip } from "../../../utils";
+import { strip } from "@/utils";
 
 export type ToastProps = PrismaneProps<
   {

--- a/src/components/Toaster/Toast/index.ts
+++ b/src/components/Toaster/Toast/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./Toast";
+export { default, type ToastProps } from "./Toast";

--- a/src/components/Toaster/Toaster.tsx
+++ b/src/components/Toaster/Toaster.tsx
@@ -1,16 +1,16 @@
 import { forwardRef, useState } from "react";
 // Components
-import Portal from "../Portal/Portal";
-import Flex, { FlexProps } from "../Flex/Flex";
+import Portal from "@components/Portal";
+import Flex, { FlexProps } from "@components/Flex";
 // Context
 import { ToasterContextProvider } from "./ToasterContext";
 // Types
-import { PrismaneProps } from "../../types";
+import { PrismaneProps } from "@/types";
 // Utils
-import { strip, fr, variants } from "../../utils";
+import { strip, fr, variants } from "@/utils";
 
 // Internal Components
-import Toast from "./Toast/Toast";
+import Toast from "./Toast";
 
 export type ToasterProps = PrismaneProps<
   {

--- a/src/components/Toaster/ToasterContext.ts
+++ b/src/components/Toaster/ToasterContext.ts
@@ -1,6 +1,6 @@
 import { Dispatch, createContext, useContext } from "react";
 // Types
-import { ToastProps } from "./Toast/Toast";
+import { ToastProps } from "./Toast";
 
 export interface ToasterContextValue {
   toasts: ToastProps[];

--- a/src/components/Toaster/useToast.ts
+++ b/src/components/Toaster/useToast.ts
@@ -1,7 +1,7 @@
 // Context
 import { useToasterContext } from "./ToasterContext";
 // Types
-import { ToastProps } from "./Toast/Toast";
+import { ToastProps } from "./Toast";
 
 const useToast = () => {
   const { setToasts }: any = useToasterContext();

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -1,21 +1,21 @@
 import { forwardRef, ReactNode, useState } from "react";
 // Components
-import Animation, { AnimationProps } from "../Animation/Animation";
-import Box from "../Box/Box";
-import Flex, { FlexProps } from "../Flex/Flex";
-import Text from "../Text/Text";
+import Animation, { AnimationProps } from "@components/Animation";
+import Box from "@components/Box";
+import Flex, { FlexProps } from "@components/Flex";
+import Text from "@components/Text";
 // Hooks
-import useAnimation from "../../hooks/useAnimation";
-import usePresence from "../../hooks/usePresence";
+import useAnimation from "@hooks/useAnimation";
+import usePresence from "@hooks/usePresence";
 // Types
 import {
   PrismanePositions,
   PrismaneBreakpoints,
   PrismaneColors,
   PrismaneProps,
-} from "../../types";
+} from "@/types";
 // Utils
-import { strip, variants, fr } from "../../utils";
+import { strip, variants, fr } from "@/utils";
 
 export type TooltipProps = PrismaneProps<
   {

--- a/src/components/Transition/Transition.tsx
+++ b/src/components/Transition/Transition.tsx
@@ -1,6 +1,6 @@
 import { forwardRef } from "react";
 // Components
-import Box, { BoxProps } from "../Box/Box";
+import Box, { BoxProps } from "@components/Box";
 // Types
 import {
   PrismaneTransitions,
@@ -8,9 +8,9 @@ import {
   PrismaneVersatile,
   PrismaneVersatileRef,
   PrismaneProps,
-} from "../../types";
+} from "@/types";
 // Utils
-import { strip } from "../../utils";
+import { strip } from "@/utils";
 
 export type TransitionProps<E extends Versatile = "div"> = PrismaneVersatile<
   E,

--- a/src/hooks/useStyling/useStyling.ts
+++ b/src/hooks/useStyling/useStyling.ts
@@ -1,11 +1,11 @@
 import { useLayoutEffect, useState } from "react";
-import { css } from "../../../stitches.config";
+import { css } from "@/../stitches.config";
 // Theme
-import { usePrismaneTheme } from "../../components/PrismaneProvider/PrismaneContext";
+import { usePrismaneTheme } from "@components/PrismaneProvider/PrismaneContext";
 // Hooks
-import useMemoization from "../useMemoization";
+import useMemoization from "@hooks/useMemoization";
 // Types
-import { PrismaneTheme } from "../../types";
+import { PrismaneTheme } from "@/types";
 
 type StylingProp =
   | any

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,15 @@
     "outDir": "dist",
     "declaration": true,
     "declarationMap": true,
-    "noErrorTruncation": true
+    "noErrorTruncation": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"],
+      "@components/*": ["src/components/*"],
+      "@hooks/*": ["src/hooks/*"],
+      "@themes/*": ["src/themes/*"],
+      "@validators/*": ["src/validators/*"]
+    }
   },
   "include": ["src", "./custom.d.ts"],
   "exclude": ["node_modules"]

--- a/vite.config.js
+++ b/vite.config.js
@@ -64,4 +64,13 @@ export default defineConfig({
       },
     },
   },
+  resolve: {
+    alias: {
+      "@": resolve(__dirname, "./src"),
+      "@components": resolve(__dirname, "./src/components"),
+      "@hooks": resolve(__dirname, "./src/hooks"),
+      "@themes": resolve(__dirname, "./src/themes"),
+      "@validators": resolve(__dirname, "./src/validators"),
+    },
+  },
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,9 +1,19 @@
 import { defineConfig } from "vitest/config";
+import { resolve } from "path";
 
 export default defineConfig({
   test: {
     globals: true,
     environment: "jsdom",
     setupFiles: "./tests.ts",
+  },
+  resolve: {
+    alias: {
+      "@": resolve(__dirname, "./src"),
+      "@components": resolve(__dirname, "./src/components"),
+      "@hooks": resolve(__dirname, "./src/hooks"),
+      "@themes": resolve(__dirname, "./src/themes"),
+      "@validators": resolve(__dirname, "./src/validators"),
+    },
   },
 });


### PR DESCRIPTION
This merge adds global TypeScript import paths to make imports cleaner throughout the package.