### PR TITLE
Fix disabled and read only fields

### DIFF
--- a/src/components/Field/Field.tsx
+++ b/src/components/Field/Field.tsx
@@ -37,14 +37,8 @@ export type FieldProps<E extends Versatile = "input"> = PrismaneVersatile<
   E,
   PrismaneProps<
     {
-      type?: string;
-      placeholder?: string;
-      readOnly?: boolean;
-      maxLength?: number;
-      minLength?: number;
       icon?: ReactNode;
       validating?: boolean;
-      disabled?: boolean;
     },
     FlexProps & TransitionProps & PrismaneFieldComponent
   >

--- a/src/components/NativeDateField/NativeDateField.tsx
+++ b/src/components/NativeDateField/NativeDateField.tsx
@@ -13,7 +13,7 @@ const NativeDateField = forwardRef<
   const [rest, field] = useFieldProps(props);
 
   return (
-    <Field.Wrapper {...rest}>
+    <Field.Wrapper pe={(field.disabled || field.readOnly) && "none"} {...rest}>
       <Field.Label
         size={size as any}
         htmlFor={field.name}

--- a/src/components/NativeSelectField/NativeSelectField.tsx
+++ b/src/components/NativeSelectField/NativeSelectField.tsx
@@ -21,7 +21,7 @@ const NativeSelectField = forwardRef<
   const [rest, field] = useFieldProps(props);
 
   return (
-    <Field.Wrapper {...rest}>
+    <Field.Wrapper pe={(field.disabled || field.readOnly) && "none"} {...rest}>
       <Field.Label
         size={size as any}
         htmlFor={field.name}

--- a/src/components/NumberField/NumberField.tsx
+++ b/src/components/NumberField/NumberField.tsx
@@ -34,7 +34,10 @@ const NumberField = forwardRef<
     const emulateChange = useEmulatedFieldChange(fieldRef, props.onChange);
 
     return (
-      <Field.Wrapper {...rest}>
+      <Field.Wrapper
+        pe={(field.disabled || field.readOnly) && "none"}
+        {...rest}
+      >
         <Field.Label
           size={size as any}
           htmlFor={field.name}

--- a/src/components/PasswordField/PasswordField.tsx
+++ b/src/components/PasswordField/PasswordField.tsx
@@ -18,7 +18,7 @@ const PasswordField = forwardRef<
   const [mutableType, setMutableType] = useState("password");
 
   return (
-    <Field.Wrapper {...rest}>
+    <Field.Wrapper pe={(field.disabled || field.readOnly) && "none"} {...rest}>
       <Field.Label
         size={size as any}
         htmlFor={field.name}

--- a/src/components/PinField/PinField.tsx
+++ b/src/components/PinField/PinField.tsx
@@ -83,7 +83,10 @@ const PinField = forwardRef<
     };
 
     return (
-      <Field.Wrapper {...rest}>
+      <Field.Wrapper
+        pe={(field.disabled || field.readOnly) && "none"}
+        {...rest}
+      >
         <Field.Label
           size={size as any}
           htmlFor={field.name}
@@ -107,6 +110,7 @@ const PinField = forwardRef<
               error={error}
               size={size as any}
               type={masked ? "password" : "text"}
+              disabled={field.disabled}
               px={fr(1)}
               py={fr(1)}
               grow={false}

--- a/src/components/SegmentedField/SegmentedField.tsx
+++ b/src/components/SegmentedField/SegmentedField.tsx
@@ -30,7 +30,10 @@ const SegmentedField = forwardRef<HTMLInputElement, SegmentedFieldProps>(
     const emulateChange = useEmulatedFieldChange(fieldRef, props.onChange);
 
     return (
-      <Field.Wrapper {...rest}>
+      <Field.Wrapper
+        pe={(field.disabled || field.readOnly) && "none"}
+        {...rest}
+      >
         <Field.Label
           size={size as any}
           htmlFor={field.name}

--- a/src/components/SelectField/SelectField.tsx
+++ b/src/components/SelectField/SelectField.tsx
@@ -89,7 +89,11 @@ const SelectField = forwardRef<any, SelectFieldProps>(
     );
 
     return (
-      <Field.Wrapper ref={wrapperRef} {...rest}>
+      <Field.Wrapper
+        pe={(field.disabled || field.readOnly) && "none"}
+        ref={wrapperRef}
+        {...rest}
+      >
         <Field.Label
           size={size as any}
           htmlFor={field.name}

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -25,7 +25,10 @@ const TextField = forwardRef<
     const [rest, field] = useFieldProps(props);
 
     return (
-      <Field.Wrapper {...rest}>
+      <Field.Wrapper
+        pe={(field.disabled || field.readOnly) && "none"}
+        {...rest}
+      >
         <Field.Label
           size={size as any}
           htmlFor={field.name}

--- a/src/components/TextareaField/TextareaField.tsx
+++ b/src/components/TextareaField/TextareaField.tsx
@@ -13,7 +13,7 @@ const TextareaField = forwardRef<
   const [rest, field] = useFieldProps(props);
 
   return (
-    <Field.Wrapper {...rest}>
+    <Field.Wrapper pe={(field.disabled || field.readOnly) && "none"} {...rest}>
       <Field.Label
         size={size as any}
         htmlFor={field.name}

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,20 +43,17 @@ export type PrismaneWithInternal<
   [K in keyof Internal]: React.ForwardRefExoticComponent<Internal[K]>;
 };
 
-export interface PrismaneFieldComponent extends PrismaneComponent {
-  name?: string;
+type PrismaneField = {
   id?: string;
   error?: string | null;
   label?: string;
-  value?: string | number;
-  defaultValue?: string | number;
-  defaultChecked?: boolean;
   size?: PrismaneBreakpoints;
   variant?: "outlined" | "filled" | "underlined" | "unstyled";
   addons?: React.ReactNode;
-  disabled?: boolean;
-  checked?: boolean;
-}
+};
+
+export type PrismaneFieldComponent = PrismaneField &
+  Omit<JSX.IntrinsicElements["input"], keyof PrismaneField>;
 
 type GlobalStyles = "inherit" | "initial" | "revert" | "revert-layer" | "unset";
 


### PR DESCRIPTION
This merge fixes the functionality of the `disabled` and `readOnly` props across multiple field components: `NativeSelectField`, `NumberField`, `PinField`, `SelectField`, `SegmentedField`, `NativeDateField`, `PasswordField`, `TextField`, `TextareaField`.