### PR TITLE
feat: add dual value support to fs prop

### DIFF
--- a/src/components/Box/Box.tsx
+++ b/src/components/Box/Box.tsx
@@ -168,7 +168,7 @@ const Box: BoxComponent = forwardRef(
       zIndex: z,
       overflow: of,
       fontFamily: ff,
-      fontSize: variants(fs, {
+      fontSize: dual(fs, {
         xs: fr(3),
         sm: fr(3.5),
         base: fr(4),


### PR DESCRIPTION
This merge makes the `fs` prop support not only Prismane's breakpoints but any other valid string or number value.