### PR TITLE
feat: add dual value support to fw prop

### DIFF
--- a/src/components/Box/Box.tsx
+++ b/src/components/Box/Box.tsx
@@ -12,7 +12,7 @@ import {
   PrismaneVersatileRef,
 } from "@/types";
 // Utils
-import { strip, dual, variants, fr } from "@/utils";
+import { strip, dual, fr } from "@/utils";
 
 export type BoxProps<E extends Versatile = "div"> = PrismaneVersatile<
   E,
@@ -183,7 +183,7 @@ const Box: BoxComponent = forwardRef(
         "7xl": fr(24),
         "8xl": fr(32),
       }),
-      fontWeight: variants(fw, {
+      fontWeight: dual(fw, {
         thin: "100",
         extralight: "200",
         light: "300",


### PR DESCRIPTION
This merge makes the `fw` prop support not only Prismane's default values but any other valid string or number value.