### PR TITLE
feat: fields to occupy full parent width

### DIFF
--- a/src/components/Field/FieldWrapper/FieldWrapper.tsx
+++ b/src/components/Field/FieldWrapper/FieldWrapper.tsx
@@ -10,6 +10,7 @@ const FieldWrapper = forwardRef<HTMLDivElement, FieldWrapperProps>(
   ({ children, className, ...props }, ref) => {
     return (
       <Flex
+        w="100%"
         direction="column"
         gap={fr(2)}
         className={strip(


### PR DESCRIPTION
This merge makes all field components to occupy the full width of the parent.