### PR TITLE
feat: add events param to useOutsideClick

### DIFF
--- a/src/hooks/useOutsideClick/useOutsideClick.test.tsx
+++ b/src/hooks/useOutsideClick/useOutsideClick.test.tsx
@@ -29,7 +29,7 @@ test("Correct callback call on outside click", () => {
 
   renderHook(() => useOutsideClick(ref, mockFn));
 
-  fireEvent.click(getByTestId("parent"));
+  fireEvent.mouseDown(getByTestId("parent"));
 
   expect(mockFn).toHaveBeenCalledTimes(1);
 });

--- a/src/hooks/useOutsideClick/useOutsideClick.ts
+++ b/src/hooks/useOutsideClick/useOutsideClick.ts
@@ -1,6 +1,10 @@
 import { useEffect } from "react";
 
-const useOutsideClick = (ref: any, cb: any) => {
+const useOutsideClick = (
+  ref: any,
+  cb: any,
+  events: string[] = ["mousedown", "touchstart"]
+) => {
   const handleClickOutside = (event: any) => {
     if (ref.current && !ref.current.contains(event.target)) {
       cb();
@@ -8,14 +12,16 @@ const useOutsideClick = (ref: any, cb: any) => {
   };
 
   useEffect(() => {
-    const handleDocumentClick = (event: any) => {
+    const handleDocumentEvent = (event: any) => {
       handleClickOutside(event);
     };
 
-    document.addEventListener("click", handleDocumentClick);
+    events.forEach((ev) => document.addEventListener(ev, handleDocumentEvent));
 
     return () => {
-      document.removeEventListener("click", handleDocumentClick);
+      events.forEach((ev) =>
+        document.removeEventListener(ev, handleDocumentEvent)
+      );
     };
   }, [cb]);
 


### PR DESCRIPTION
This merge adds a third parameter to the `useOutsideClick` hook, which enables us to define an array of events that the callback should be called on.