### PR TITLE
perf: improve Portal component

### DIFF
--- a/src/components/Portal/Portal.stories.tsx
+++ b/src/components/Portal/Portal.stories.tsx
@@ -35,3 +35,20 @@ export const Custom_Container = () => {
     </Box>
   );
 };
+
+export const Disabled = () => {
+  const ref = useRef(null);
+
+  return (
+    <Box bg="orange" cl="white">
+      This will be rendered inside the box
+      <Portal target={ref} disabled>
+        This will be rendered inside the orange box, because the portal is
+        disabled.
+      </Portal>
+      <Box ref={ref} bg="ruby">
+        This is the ruby box.
+      </Box>
+    </Box>
+  );
+};

--- a/src/components/Portal/Portal.tsx
+++ b/src/components/Portal/Portal.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useState, useEffect } from "react";
+import { forwardRef } from "react";
 import ReactDOM from "react-dom";
 // Components
 import Box, { BoxProps } from "@components/Box";
@@ -17,17 +17,7 @@ export type PortalProps = PrismaneProps<
 
 const Portal = forwardRef<HTMLDivElement, PortalProps>(
   ({ target, disabled = false, className, children, ...props }, ref) => {
-    const [node, setNode] = useState<HTMLElement | null>(null);
-
-    useEffect(() => {
-      if (target && target.current) {
-        setNode(target.current);
-      }
-
-      if (target === undefined) {
-        setNode(document.body);
-      }
-    }, [target]);
+    const node = target?.current ?? globalThis.document.body;
 
     if (!node) {
       return null;


### PR DESCRIPTION
This merge improves the performance of the `Portal` component, removing the unnecessary usage of `useState` and `useEffect` hooks.