### PR TITLE
feat: make Table to occupy the entire parent width

### DIFF
--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -30,6 +30,7 @@ const Table = forwardRef<HTMLTableElement, TableProps>(
     return (
       <Box
         as="table"
+        w="100%"
         sx={{
           borderCollapse: "collapse",
           ...sx,

--- a/src/components/Table/TableCell/TableCell.tsx
+++ b/src/components/Table/TableCell/TableCell.tsx
@@ -11,6 +11,7 @@ const TableCell = forwardRef<HTMLTableSectionElement, TableCellProps>(
     return (
       <Box
         as="td"
+        ta="start"
         py={fr(3)}
         px={fr(6)}
         cl={(theme) => (theme.mode === "dark" ? "white" : ["base", 900])}


### PR DESCRIPTION
This merge makes the `Table` component occupy the entire width of its parent.