### PR TITLE
fix: fix TableHead border

### DIFF
--- a/src/components/Table/TableBody/TableBody.tsx
+++ b/src/components/Table/TableBody/TableBody.tsx
@@ -7,10 +7,19 @@ import { strip } from "@/utils";
 export type TableBodyProps = BoxProps<"tbody">;
 
 const TableBody = forwardRef<HTMLTableSectionElement, TableBodyProps>(
-  ({ children, className, ...props }, ref) => {
+  ({ children, className, sx, ...props }, ref) => {
     return (
       <Box
         as="tbody"
+        sx={{
+          "& > .PrismaneTableRow-root:first-child": {
+            borderTopWidth: 1,
+          },
+          "& > .PrismaneTableRow-root": {
+            borderBottomWidth: 1,
+          },
+          ...sx,
+        }}
         className={strip(
           `${className ? className : ""} PrismaneTableBody-root`
         )}

--- a/src/components/Table/TableCell/TableCell.tsx
+++ b/src/components/Table/TableCell/TableCell.tsx
@@ -15,8 +15,6 @@ const TableCell = forwardRef<HTMLTableSectionElement, TableCellProps>(
         py={fr(3)}
         px={fr(6)}
         cl={(theme) => (theme.mode === "dark" ? "white" : ["base", 900])}
-        bdtw={1}
-        bdc={(theme) => (theme.mode === "dark" ? ["base", 700] : ["base", 300])}
         className={strip(
           `${className ? className : ""} PrismaneTableCell-root`
         )}

--- a/src/components/Table/TableRow/TableRow.tsx
+++ b/src/components/Table/TableRow/TableRow.tsx
@@ -12,6 +12,7 @@ const TableRow = forwardRef<HTMLTableSectionElement, TableRowProps>(
       <Box
         as="tr"
         w="100%"
+        bdc={(theme) => (theme.mode === "dark" ? ["base", 700] : ["base", 300])}
         className={strip(`${className ? className : ""} PrismaneTableRow-root`)}
         data-testid="prismane-table-row"
         ref={ref}


### PR DESCRIPTION
This merge fixes an issue where a border was shown in the `Table.Head` component.