### PR TITLE
feat: add table variants

### DIFF
--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -1,5 +1,8 @@
+import { useState } from "react";
 // Components
 import Table from "../Table/Table";
+import Radio from "../Radio";
+import Stack from "../Stack";
 
 export default {
   tags: ["autodocs"],
@@ -9,10 +12,8 @@ export default {
 
 export const Default = () => (
   <Table>
-    <Table.Caption ta="center">
-      Imperial to metric conversion factors
-    </Table.Caption>
-    <Table.Head ta="center">
+    <Table.Caption>Imperial to metric conversion factors</Table.Caption>
+    <Table.Head>
       <Table.Row>
         <Table.Cell>To convert</Table.Cell>
         <Table.Cell>into</Table.Cell>
@@ -31,7 +32,7 @@ export const Default = () => (
         <Table.Cell>30.48</Table.Cell>
       </Table.Row>
     </Table.Body>
-    <Table.Foot ta="center">
+    <Table.Foot>
       <Table.Row>
         <Table.Cell>To convert</Table.Cell>
         <Table.Cell>into</Table.Cell>
@@ -40,3 +41,191 @@ export const Default = () => (
     </Table.Foot>
   </Table>
 );
+
+export const Various_Column_Widths = () => (
+  <Table>
+    <Table.Caption>Imperial to metric conversion factors</Table.Caption>
+    <Table.Head>
+      <Table.Row>
+        <Table.Cell w="160px">To convert (160px)</Table.Cell>
+        <Table.Cell w="20%">into (20%)</Table.Cell>
+        <Table.Cell>multiply by (auto)</Table.Cell>
+      </Table.Row>
+    </Table.Head>
+    <Table.Body>
+      <Table.Row>
+        <Table.Cell>inches</Table.Cell>
+        <Table.Cell>millimeters</Table.Cell>
+        <Table.Cell>25.4</Table.Cell>
+      </Table.Row>
+      <Table.Row>
+        <Table.Cell>feet</Table.Cell>
+        <Table.Cell>centimeters</Table.Cell>
+        <Table.Cell>30.48</Table.Cell>
+      </Table.Row>
+    </Table.Body>
+    <Table.Foot>
+      <Table.Row>
+        <Table.Cell>To convert</Table.Cell>
+        <Table.Cell>into</Table.Cell>
+        <Table.Cell>multiply by</Table.Cell>
+      </Table.Row>
+    </Table.Foot>
+  </Table>
+);
+
+export const Bordered_Table = () => {
+  return (
+    <Table bordered>
+      <Table.Head>
+        <Table.Row>
+          <Table.Cell>To convert</Table.Cell>
+          <Table.Cell>into</Table.Cell>
+          <Table.Cell>multiply by</Table.Cell>
+        </Table.Row>
+      </Table.Head>
+      <Table.Body>
+        <Table.Row>
+          <Table.Cell>inches</Table.Cell>
+          <Table.Cell>millimeters</Table.Cell>
+          <Table.Cell>25.4</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Cell>feet</Table.Cell>
+          <Table.Cell>centimeters</Table.Cell>
+          <Table.Cell>30.48</Table.Cell>
+        </Table.Row>
+      </Table.Body>
+      <Table.Foot>
+        <Table.Row>
+          <Table.Cell>To convert</Table.Cell>
+          <Table.Cell>into</Table.Cell>
+          <Table.Cell>multiply by</Table.Cell>
+        </Table.Row>
+      </Table.Foot>
+    </Table>
+  );
+};
+
+export const Table_Lines = () => {
+  const [lines, setLines] = useState<"horizontal" | "vertical" | "both">(
+    "horizontal"
+  );
+
+  return (
+    <Stack>
+      <Radio.Group
+        value={lines}
+        onChange={(e: any) => setLines(e.target.value)}
+      >
+        <Radio value="horizontal" label="Horizontal" />
+        <Radio value="vertical" label="Vertical" />
+        <Radio value="both" label="Both" />
+      </Radio.Group>
+      <Table lines={lines}>
+        <Table.Head>
+          <Table.Row>
+            <Table.Cell>To convert</Table.Cell>
+            <Table.Cell>into</Table.Cell>
+            <Table.Cell>multiply by</Table.Cell>
+          </Table.Row>
+        </Table.Head>
+        <Table.Body>
+          <Table.Row>
+            <Table.Cell>inches</Table.Cell>
+            <Table.Cell>millimeters</Table.Cell>
+            <Table.Cell>25.4</Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Cell>feet</Table.Cell>
+            <Table.Cell>centimeters</Table.Cell>
+            <Table.Cell>30.48</Table.Cell>
+          </Table.Row>
+        </Table.Body>
+        <Table.Foot>
+          <Table.Row>
+            <Table.Cell>To convert</Table.Cell>
+            <Table.Cell>into</Table.Cell>
+            <Table.Cell>multiply by</Table.Cell>
+          </Table.Row>
+        </Table.Foot>
+      </Table>
+    </Stack>
+  );
+};
+
+export const Striped = () => {
+  return (
+    <Table striped>
+      <Table.Head>
+        <Table.Row>
+          <Table.Cell>To convert</Table.Cell>
+          <Table.Cell>into</Table.Cell>
+          <Table.Cell>multiply by</Table.Cell>
+        </Table.Row>
+      </Table.Head>
+      <Table.Body>
+        <Table.Row>
+          <Table.Cell>inches</Table.Cell>
+          <Table.Cell>millimeters</Table.Cell>
+          <Table.Cell>25.4</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Cell>feet</Table.Cell>
+          <Table.Cell>centimeters</Table.Cell>
+          <Table.Cell>30.48</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Cell>meters</Table.Cell>
+          <Table.Cell>centimeters</Table.Cell>
+          <Table.Cell>100</Table.Cell>
+        </Table.Row>
+      </Table.Body>
+      <Table.Foot>
+        <Table.Row>
+          <Table.Cell>To convert</Table.Cell>
+          <Table.Cell>into</Table.Cell>
+          <Table.Cell>multiply by</Table.Cell>
+        </Table.Row>
+      </Table.Foot>
+    </Table>
+  );
+};
+
+export const Striped_No_Lines = () => {
+  return (
+    <Table lines="none" striped>
+      <Table.Head>
+        <Table.Row>
+          <Table.Cell>To convert</Table.Cell>
+          <Table.Cell>into</Table.Cell>
+          <Table.Cell>multiply by</Table.Cell>
+        </Table.Row>
+      </Table.Head>
+      <Table.Body>
+        <Table.Row>
+          <Table.Cell>inches</Table.Cell>
+          <Table.Cell>millimeters</Table.Cell>
+          <Table.Cell>25.4</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Cell>feet</Table.Cell>
+          <Table.Cell>centimeters</Table.Cell>
+          <Table.Cell>30.48</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Cell>meters</Table.Cell>
+          <Table.Cell>centimeters</Table.Cell>
+          <Table.Cell>100</Table.Cell>
+        </Table.Row>
+      </Table.Body>
+      <Table.Foot>
+        <Table.Row>
+          <Table.Cell>To convert</Table.Cell>
+          <Table.Cell>into</Table.Cell>
+          <Table.Cell>multiply by</Table.Cell>
+        </Table.Row>
+      </Table.Foot>
+    </Table>
+  );
+};

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -1,8 +1,10 @@
 import { forwardRef } from "react";
 // Components
 import Box, { BoxProps } from "@components/Box";
+// Context
+import { TableContextProvider } from "./TableContext";
 // Types
-import { PrismaneWithInternal } from "@/types";
+import { PrismaneWithInternal, PrismaneProps } from "@/types";
 // Utils
 import { strip } from "@/utils";
 
@@ -23,25 +25,57 @@ export {
   type TableCaptionProps,
 };
 
-export type TableProps = BoxProps<"table">;
+export type TableProps = PrismaneProps<
+  {
+    lines?: "vertical" | "horizontal" | "both" | "none";
+    striped?: boolean;
+    bordered?: boolean;
+  },
+  BoxProps<"table">
+>;
 
 const Table = forwardRef<HTMLTableElement, TableProps>(
-  ({ children, className, sx, ...props }, ref) => {
+  (
+    {
+      lines = "horizontal",
+      striped = false,
+      bordered = false,
+      children,
+      className,
+      sx,
+      ...props
+    },
+    ref
+  ) => {
     return (
-      <Box
-        as="table"
-        w="100%"
-        sx={{
-          borderCollapse: "collapse",
-          ...sx,
+      <TableContextProvider
+        value={{
+          lines,
+          striped,
         }}
-        className={strip(`${className ? className : ""} PrismaneTable-root`)}
-        data-testid="prismane-table"
-        ref={ref}
-        {...props}
       >
-        {children}
-      </Box>
+        <Box
+          as="table"
+          w="100%"
+          bdc={(theme) =>
+            theme.mode === "dark" ? ["base", 700] : ["base", 300]
+          }
+          sx={{
+            borderCollapse: "collapse",
+            borderWidth: bordered ? 1 : 0,
+            "& .PrismaneTableCell-root:not(:first-child)": {
+              borderLeftWidth: (lines === "vertical" || lines === "both") && 1,
+            },
+            ...sx,
+          }}
+          className={strip(`${className ? className : ""} PrismaneTable-root`)}
+          data-testid="prismane-table"
+          ref={ref}
+          {...props}
+        >
+          {children}
+        </Box>
+      </TableContextProvider>
     );
   }
 ) as PrismaneWithInternal<

--- a/src/components/Table/TableBody/TableBody.tsx
+++ b/src/components/Table/TableBody/TableBody.tsx
@@ -1,6 +1,10 @@
 import { forwardRef } from "react";
 // Components
 import Box, { BoxProps } from "@components/Box";
+// Hooks
+import { usePrismaneColor } from "@/components/PrismaneProvider";
+// Context
+import { useTableContext } from "../TableContext";
 // Utils
 import { strip } from "@/utils";
 
@@ -8,15 +12,27 @@ export type TableBodyProps = BoxProps<"tbody">;
 
 const TableBody = forwardRef<HTMLTableSectionElement, TableBodyProps>(
   ({ children, className, sx, ...props }, ref) => {
+    const { lines, striped } = useTableContext();
+
+    const { getColorStyle } = usePrismaneColor();
+
     return (
       <Box
         as="tbody"
         sx={{
           "& > .PrismaneTableRow-root:first-child": {
-            borderTopWidth: 1,
+            borderTopWidth: (lines === "horizontal" || lines === "both") && 1,
           },
           "& > .PrismaneTableRow-root": {
-            borderBottomWidth: 1,
+            borderBottomWidth:
+              (lines === "horizontal" || lines === "both") && 1,
+          },
+          "& > .PrismaneTableRow-root:nth-child(odd)": {
+            background: (theme) =>
+              striped &&
+              (theme.mode === "dark"
+                ? getColorStyle(["base", 600, 0.2])
+                : getColorStyle(["base", 300, 0.2])),
           },
           ...sx,
         }}

--- a/src/components/Table/TableCell/TableCell.tsx
+++ b/src/components/Table/TableCell/TableCell.tsx
@@ -11,10 +11,10 @@ const TableCell = forwardRef<HTMLTableSectionElement, TableCellProps>(
     return (
       <Box
         as="td"
-        ta="start"
         py={fr(3)}
         px={fr(6)}
         cl={(theme) => (theme.mode === "dark" ? "white" : ["base", 900])}
+        bdc={(theme) => (theme.mode === "dark" ? ["base", 700] : ["base", 300])}
         className={strip(
           `${className ? className : ""} PrismaneTableCell-root`
         )}

--- a/src/components/Table/TableContext.ts
+++ b/src/components/Table/TableContext.ts
@@ -1,0 +1,15 @@
+import { createContext, useContext } from "react";
+
+export interface TableContextValue {
+  lines?: "vertical" | "horizontal" | "both" | "none";
+  striped?: boolean;
+}
+
+const TableContext = createContext<TableContextValue>({
+  lines: "horizontal",
+  striped: false,
+});
+
+export const TableContextProvider = TableContext.Provider;
+
+export const useTableContext = () => useContext(TableContext);


### PR DESCRIPTION
This merge adds three new props to the `Table` component - `lines`, `striped`, `bordered` that control the visual appearance of the table.