### PR TITLE
feat: add classnames library to cx util

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "@fontsource/poppins": "^4.5.10",
     "@phosphor-icons/react": "^2.0.9",
     "@stitches/react": "^1.2.8",
+    "classnames": "^2.5.1",
     "csstype": "^3.1.3"
   },
   "peerDependencies": {

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -8,7 +8,7 @@ import { AccordionContextProvider } from "./AccordionContext";
 // Types
 import { PrismaneWithInternal, PrismaneProps } from "@types";
 // Utils
-import { strip } from "@utils";
+import { cx } from "@utils";
 
 // Internal Components
 import AccordionControl, { AccordionControlProps } from "./AccordionControl";
@@ -38,9 +38,7 @@ const Accordion = forwardRef<HTMLDivElement, AccordionProps>(
       <Flex
         direction="column"
         w="100%"
-        className={strip(
-          `${className ? className : ""} PrismaneAccordion-root`
-        )}
+        className={cx("PrismaneAccordion-root", className)}
         data-testid="prismane-accordion"
         ref={ref}
         {...props}

--- a/src/components/Accordion/AccordionControl/AccordionControl.tsx
+++ b/src/components/Accordion/AccordionControl/AccordionControl.tsx
@@ -10,7 +10,7 @@ import { useAccordionItemContext } from "../AccordionItem/AccordionItemContext";
 // Types
 import { PrismaneProps } from "@types";
 // Utils
-import { strip, fr } from "@utils";
+import { cx, fr } from "@utils";
 
 export type AccordionControlProps = PrismaneProps<FlexProps, TransitionProps>;
 
@@ -37,11 +37,9 @@ const AccordionControl = forwardRef<HTMLDivElement, AccordionControlProps>(
         onClick={() => {
           value === item ? setValue(null) : setValue(item);
         }}
-        className={strip(
-          `${className ? className : ""} ${
-            value === item ? "PrismaneAccordionControl-root-active" : ""
-          } PrismaneAccordionControl-root`
-        )}
+        className={cx("PrismaneAccordionControl-root", className, {
+          "PrismaneAccordionControl-root-active": value === item,
+        })}
         data-testid="prismane-accordion-control"
         ref={ref}
         {...props}

--- a/src/components/Accordion/AccordionIcon/AccordionIcon.tsx
+++ b/src/components/Accordion/AccordionIcon/AccordionIcon.tsx
@@ -11,7 +11,7 @@ import { useAccordionItemContext } from "../AccordionItem/AccordionItemContext";
 // Types
 import { PrismaneProps } from "@types";
 // Utils
-import { strip } from "@utils";
+import { cx } from "@utils";
 
 export type AccordionIconProps = PrismaneProps<
   {
@@ -28,11 +28,9 @@ const AccordionIcon = forwardRef<HTMLDivElement, AccordionIconProps>(
 
     return (
       <Flex
-        className={strip(
-          `${className ? className : ""} ${
-            value === item ? "PrismaneAccordionIcon-root-active" : ""
-          } PrismaneAccordionIcon-root`
-        )}
+        className={cx("PrismaneAccordionIcon-root", className, {
+          "PrismaneAccordionIcon-root-active": value === item,
+        })}
         data-testid="prismane-accordion-icon"
         ref={ref}
         {...props}

--- a/src/components/Accordion/AccordionItem/AccordionItem.tsx
+++ b/src/components/Accordion/AccordionItem/AccordionItem.tsx
@@ -8,7 +8,7 @@ import { AccordionItemContextProvider } from "./AccordionItemContext";
 // Types
 import { PrismaneProps } from "@types";
 // Utils
-import { strip } from "@utils";
+import { cx } from "@utils";
 
 export type AccordionItemProps = PrismaneProps<
   {
@@ -28,9 +28,7 @@ const AccordionItem = forwardRef<HTMLDivElement, AccordionItemProps>(
           theme.mode === "dark" ? ["base", 700] : ["base", 200]
         }
         cl={(theme) => (theme.mode === "dark" ? ["base", 200] : ["base", 700])}
-        className={strip(
-          `${className ? className : ""} PrismaneAccordionItem-root`
-        )}
+        className={cx("PrismaneAccordionItem-root", className)}
         data-testid="prismane-accordion-item"
         ref={ref}
         {...props}

--- a/src/components/Accordion/AccordionPanel/AccordionPanel.tsx
+++ b/src/components/Accordion/AccordionPanel/AccordionPanel.tsx
@@ -8,7 +8,7 @@ import Animation, { AnimationProps } from "@components/Animation";
 import { useAccordionContext } from "../AccordionContext";
 import { useAccordionItemContext } from "../AccordionItem/AccordionItemContext";
 // Utils
-import { strip, fr } from "@utils";
+import { cx, fr } from "@utils";
 
 export type AccordionPanelProps = AnimationProps;
 
@@ -47,11 +47,9 @@ const AccordionPanel = forwardRef<HTMLDivElement, AccordionPanelProps>(
           },
         }}
         animated={open}
-        className={strip(
-          `${className ? className : ""} ${
-            value === item ? "PrismaneAccordionPanel-root-active" : ""
-          } PrismaneAccordionPanel-root`
-        )}
+        className={cx("PrismaneAccordionPanel-root", className, {
+          "PrismaneAccordionPanel-root-active": value === item,
+        })}
         data-testid="prismane-accordion-panel"
         ref={ref}
         {...props}

--- a/src/components/ActionButton/ActionButton.tsx
+++ b/src/components/ActionButton/ActionButton.tsx
@@ -4,7 +4,7 @@ import React, { forwardRef } from "react";
 // Components
 import Button, { ButtonProps } from "@components/Button";
 // Utils
-import { fr, variants } from "@utils";
+import { cx, fr, variants } from "@utils";
 
 export type ActionButtonProps = ButtonProps;
 
@@ -15,6 +15,7 @@ const ActionButton = forwardRef<any, ActionButtonProps>(
       color = "primary",
       variant = "tertiary",
       children,
+      className,
       ...props
     },
     ref
@@ -39,6 +40,11 @@ const ActionButton = forwardRef<any, ActionButtonProps>(
         size={size}
         color={color}
         variant={variant}
+        className={cx("PrismaneActionButton-root", className, {
+          [`PrismaneActionButton-${size}`]: true,
+          [`PrismaneActionButton-${color}`]: true,
+          [`PrismaneActionButton-${variant}`]: true,
+        })}
         data-testid="prismane-action-button"
         {...props}
       >

--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -17,7 +17,7 @@ import usePresence from "@hooks/usePresence";
 // Types
 import { PrismaneActions, PrismaneWithInternal, PrismaneProps } from "@types";
 // Utils
-import { strip, variants, fr } from "@utils";
+import { cx, variants, fr } from "@utils";
 
 // Internal Components
 import AlertTitle, { AlertTitleProps } from "./AlertTitle";
@@ -93,18 +93,18 @@ const Alert = forwardRef<HTMLDivElement, AlertProps>(
                     info: ["diamond", 700],
                   })
             }
-            className={strip(
-              `${
-                className ? className : ""
-              } PrismaneAlert-root PrismaneAlert-root-${variant}`
-            )}
+            className={cx("PrismaneAlert-root", className, {
+              [`PrismaneAlert-root-${variant}`]: true,
+            })}
             data-testid="prismane-alert"
             ref={ref}
             {...props}
           >
             <Flex
               align="center"
-              className={`PrismaneAlert-icon PrismaneAlert-icon-${variant}`}
+              className={cx("PrismaneAlert-icon", {
+                [`PrismaneAlert-icon-${variant}`]: true,
+              })}
             >
               {variant === "warning" ? (
                 icon ? (
@@ -150,7 +150,9 @@ const Alert = forwardRef<HTMLDivElement, AlertProps>(
               direction="column"
               fs="sm"
               gap={fr(2)}
-              className={`PrismaneAlert-text PrismaneAlert-text-${variant}`}
+              className={cx("PrismaneAlert-text", {
+                [`PrismaneAlert-text-${variant}`]: true,
+              })}
             >
               {children}
             </Flex>
@@ -164,7 +166,9 @@ const Alert = forwardRef<HTMLDivElement, AlertProps>(
                 onClick={() => {
                   setShown(false);
                 }}
-                className={`PrismaneAlert-action PrismaneAlert-action-${variant}`}
+                className={cx("PrismaneAlert-action", {
+                  [`PrismaneAlert-action-${variant}`]: true,
+                })}
               >
                 {action ? (
                   action

--- a/src/components/Alert/AlertDescription/AlertDescription.tsx
+++ b/src/components/Alert/AlertDescription/AlertDescription.tsx
@@ -4,7 +4,7 @@ import React, { forwardRef } from "react";
 // Components
 import Text, { TextProps } from "@components/Text";
 // Utils
-import { strip } from "@utils";
+import { cx } from "@utils";
 
 export type AlertDescriptionProps = TextProps;
 
@@ -14,9 +14,7 @@ const AlertDescription = forwardRef<HTMLSpanElement, AlertDescriptionProps>(
       <Text
         maw="xl"
         cl="inherit"
-        className={strip(
-          `${className ? className : ""} PrismaneAlertDescription-root`
-        )}
+        className={cx("PrismaneAlertDescription-root", className)}
         data-testid="prismane-alert-description"
         ref={ref}
         {...props}

--- a/src/components/Alert/AlertTitle/AlertTitle.tsx
+++ b/src/components/Alert/AlertTitle/AlertTitle.tsx
@@ -4,7 +4,7 @@ import React, { forwardRef } from "react";
 // Components
 import Text, { TextProps } from "@components/Text";
 // Utils
-import { strip } from "@utils";
+import { cx } from "@utils";
 
 export type AlertTitleProps = TextProps;
 
@@ -15,9 +15,7 @@ const AlertTitle = forwardRef<HTMLSpanElement, AlertTitleProps>(
         fw="bold"
         fs="base"
         cl="inherit"
-        className={strip(
-          `${className ? className : ""} PrismaneAlertTitle-root`
-        )}
+        className={cx("PrismaneAlertTitle-root", className)}
         data-testid="prismane-alert-title"
         ref={ref}
         {...props}

--- a/src/components/Animation/Animation.tsx
+++ b/src/components/Animation/Animation.tsx
@@ -12,7 +12,7 @@ import {
   PrismaneProps,
 } from "@types";
 // Utils
-import { strip } from "@utils";
+import { cx } from "@utils";
 
 export interface Animation {
   in: object;
@@ -146,9 +146,7 @@ const Animation: AnimationComponent = forwardRef(
     return (
       <Transition
         as={Component}
-        className={strip(
-          `${className ? className : ""} PrismaneAnimation-root`
-        )}
+        className={cx("PrismaneAnimation-root", className)}
         transition={transition}
         duration={duration}
         delay={delay}

--- a/src/components/AspectRatio/AspectRatio.tsx
+++ b/src/components/AspectRatio/AspectRatio.tsx
@@ -6,7 +6,7 @@ import Box, { BoxProps } from "@components/Box";
 // Types
 import { PrismaneStyles, PrismaneProps } from "@types";
 // Utils
-import { strip } from "@utils";
+import { cx } from "@utils";
 
 export type AspectRatioProps = PrismaneProps<
   {
@@ -20,9 +20,7 @@ const AspectRatio = forwardRef<HTMLDivElement, AspectRatioProps>(
   ({ ratio, size, children, className, style, ...props }, ref) => {
     return (
       <Box
-        className={strip(
-          `${className ? className : ""} PrismaneAspectRatio-root`
-        )}
+        className={cx("PrismaneAspectRatio-root", className)}
         w={size}
         style={{
           aspectRatio: ratio,

--- a/src/components/AutocompleteField/AutocompleteField.tsx
+++ b/src/components/AutocompleteField/AutocompleteField.tsx
@@ -8,7 +8,7 @@ import useDebounce from "@hooks/useDebounce";
 // Types
 import { PrismaneProps } from "@types";
 // Utils
-import { strip } from "@utils";
+import { cx } from "@utils";
 
 export type AutocompleteFieldProps = PrismaneProps<
   {
@@ -50,9 +50,7 @@ const AutocompleteField = forwardRef<
     <SelectField
       readOnly={false}
       options={filtered}
-      className={strip(
-        `${className ? className : ""} PrismaneAutocompleteField-root`
-      )}
+      className={cx("PrismaneAutocompleteField-root", className)}
       data-testid="prismane-autocomplete-field"
       ref={ref}
       {...props}

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -18,7 +18,7 @@ import {
   PrismaneProps,
 } from "@types";
 // Utils
-import { strip, variants, fr } from "@utils";
+import { cx, variants, fr } from "@utils";
 
 export type AvatarProps<E extends Versatile = "div"> = PrismaneVersatile<
   E,
@@ -76,11 +76,9 @@ const Avatar: AvatarComponent = forwardRef(
           overflow: "hidden",
           ...sx,
         }}
-        className={strip(
-          `${
-            className ? className : ""
-          } PrismaneAvatar-root-${size} PrismaneAvatar-root`
-        )}
+        className={cx("PrismaneAvatar-root", className, {
+          [`PrismaneAvatar-root-${size}`]: true,
+        })}
         ref={ref}
         data-testid="prismane-avatar"
         {...props}

--- a/src/components/Backdrop/Backdrop.tsx
+++ b/src/components/Backdrop/Backdrop.tsx
@@ -4,7 +4,7 @@ import React, { forwardRef } from "react";
 // Components
 import Center, { CenterProps } from "@components/Center";
 // Utils
-import { strip } from "@utils";
+import { cx } from "@utils";
 
 export type BackdropProps = CenterProps;
 
@@ -23,7 +23,7 @@ const Backdrop = forwardRef<HTMLDivElement, BackdropProps>(
         bg={(theme) =>
           theme.mode === "dark" ? ["base", 900, 0.2] : ["base", 500, 0.2]
         }
-        className={strip(`${className ? className : ""} PrismaneBackdrop-root`)}
+        className={cx("PrismaneBackdrop-root", className)}
         ref={ref}
         data-testid="prismane-backdrop"
         {...props}

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -15,7 +15,7 @@ import {
   PrismaneProps,
 } from "@types";
 // Utils
-import { strip, variants, fr } from "@utils";
+import { cx, variants, fr } from "@utils";
 
 export type BadgeProps<E extends Versatile = "div"> = PrismaneVersatile<
   E,
@@ -139,11 +139,11 @@ const Badge: BadgeComponent = forwardRef(
             whiteSpace: "nowrap",
             ...sx,
           }}
-          className={strip(
-            `${
-              className ? className : ""
-            } PrismaneBadge-root-${position} PrismaneBadge-root-${color} PrismaneBadge-root-${size} PrismaneBadge-root`
-          )}
+          className={cx("PrismaneBadge-root", className, {
+            [`PrismaneBadge-root-${position}`]: true,
+            [`PrismaneBadge-root-${color}`]: true,
+            [`PrismaneBadge-root-${size}`]: true,
+          })}
           ref={ref}
           data-testid="prismane-badge"
           {...props}

--- a/src/components/Box/Box.tsx
+++ b/src/components/Box/Box.tsx
@@ -15,7 +15,7 @@ import {
   PrismaneVersatileRef,
 } from "@types";
 // Utils
-import { strip, dual, fr } from "@utils";
+import { cx, dual, fr } from "@utils";
 
 export type BoxProps<E extends Versatile = "div"> = PrismaneVersatile<
   E,
@@ -242,9 +242,7 @@ const Box: BoxComponent = forwardRef(
 
     return (
       <El
-        className={strip(
-          `${styles.join(" ")} ${className ? className : ""} PrismaneBox-root`
-        )}
+        className={cx("PrismaneBox-root", className, styles.join(" "))}
         data-testid="prismane-box"
         ref={ref}
         {...props}

--- a/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.tsx
@@ -6,7 +6,7 @@ import Flex, { FlexProps } from "@components/Flex";
 // Types
 import { PrismaneWithInternal } from "@types";
 // Utils
-import { strip, fr } from "@utils";
+import { cx, fr } from "@utils";
 
 // Internal Components
 import BreadcrumbItem, { BreadcrumbItemProps } from "./BreadcrumbItem";
@@ -23,9 +23,7 @@ const Breadcrumb = forwardRef<HTMLDivElement, BreadcrumbProps>(
     return (
       <Flex
         align="center"
-        className={strip(
-          `${className ? className : ""} PrismaneBreadcrumb-root`
-        )}
+        className={cx("PrismaneBreadcrumb-root", className)}
         gap={fr(2)}
         cl="primary"
         data-testid="prismane-breadcrumb"

--- a/src/components/Breadcrumb/BreadcrumbItem/BreadcrumbItem.tsx
+++ b/src/components/Breadcrumb/BreadcrumbItem/BreadcrumbItem.tsx
@@ -7,7 +7,7 @@ import Link from "@components/Link";
 // Types
 import { Versatile, PrismaneVersatile, PrismaneVersatileRef } from "@types";
 // Utils
-import { strip } from "@utils";
+import { cx } from "@utils";
 
 export type BreadcrumbItemProps<E extends Versatile = typeof Link> =
   PrismaneVersatile<E, FlexProps>;
@@ -24,9 +24,7 @@ const BreadcrumbItem = forwardRef(
         as={Component}
         align="center"
         justify="center"
-        className={strip(
-          `${className ? className : ""} PrismaneBreadcrumbItem-root`
-        )}
+        className={cx("PrismaneBreadcrumbItem-root", className)}
         data-testid="prismane-breadcrumb-item"
         ref={ref}
         {...props}

--- a/src/components/Breadcrumb/BreadcrumbSeparator/BreadcrumbSeparator.tsx
+++ b/src/components/Breadcrumb/BreadcrumbSeparator/BreadcrumbSeparator.tsx
@@ -4,7 +4,7 @@ import React, { forwardRef } from "react";
 // Components
 import Flex, { FlexProps } from "@components/Flex";
 // Utils
-import { strip } from "@utils";
+import { cx } from "@utils";
 
 export type BreadcrumbSeparatorProps = FlexProps;
 
@@ -17,9 +17,7 @@ const BreadcrumbSeparator = forwardRef<
       align="center"
       justify="center"
       cl={(theme) => (theme.mode === "dark" ? ["base", 700] : ["base", 300])}
-      className={strip(
-        `${className ? className : ""} PrismaneBreadcrumbSeparator-root`
-      )}
+      className={cx("PrismaneBreadcrumbSeparator-root", className)}
       data-testid="prismane-breadcrumb-separator"
       ref={ref}
       {...props}

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -16,7 +16,7 @@ import {
   PrismaneProps,
 } from "@types";
 // Utils
-import { strip, variants, fr } from "@utils";
+import { cx, variants, fr } from "@utils";
 
 export type ButtonProps<E extends Versatile = "button"> = PrismaneVersatile<
   E,
@@ -178,11 +178,11 @@ const Button: ButtonComponent = forwardRef(
           }),
           ...sx,
         }}
-        className={strip(
-          `${
-            className ? className : ""
-          } PrismaneButton-${size} PrismaneButton-${color} PrismaneButton-${variant} PrismaneButton-root`
-        )}
+        className={cx("PrismaneButton-root", className, {
+          [`PrismaneButton-${size}`]: true,
+          [`PrismaneButton-${color}`]: true,
+          [`PrismaneButton-${variant}`]: true,
+        })}
         type={type}
         disabled={loading || disabled}
         ref={ref}
@@ -201,7 +201,7 @@ const Button: ButtonComponent = forwardRef(
             sx={{
               order: iconPosition === "right" ? 1 : -1,
             }}
-            className="PrismaneButton-icon"
+            className={"PrismaneButton-icon"}
           >
             {icon}
           </Icon>
@@ -209,7 +209,7 @@ const Button: ButtonComponent = forwardRef(
         {loading && <Spinner size={size} />}
         {children && (
           <Text
-            className="PrismaneButton-text"
+            className={"PrismaneButton-text"}
             cl="inherit"
             fs={variants(size, {
               xs: "xs",

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -11,7 +11,7 @@ import {
   PrismaneVersatileRef,
 } from "@types";
 // Utils
-import { strip, fr } from "@utils";
+import { cx, fr } from "@utils";
 
 // Internal Components
 import CardHeader, { CardHeaderProps } from "./CardHeader";
@@ -35,7 +35,7 @@ const Card = forwardRef(
       <Paper
         as={Component}
         p={fr(5)}
-        className={strip(`${className ? className : ""} PrismaneCard-root`)}
+        className={cx("PrismaneCard-root", className)}
         shadow
         data-testid="prismane-card"
         ref={ref}

--- a/src/components/Card/CardFooter/CardFooter.tsx
+++ b/src/components/Card/CardFooter/CardFooter.tsx
@@ -4,7 +4,7 @@ import React, { forwardRef } from "react";
 // Components
 import Flex, { FlexProps } from "@components/Flex";
 // Utils
-import { strip, fr } from "@utils";
+import { cx, fr } from "@utils";
 
 export type CardFooterProps = FlexProps;
 
@@ -15,9 +15,7 @@ const CardFooter = forwardRef<HTMLDivElement, CardFooterProps>(
         of="hidden"
         w="100%"
         mt={fr(4)}
-        className={strip(
-          `${className ? className : ""} PrismaneCardFooter-root`
-        )}
+        className={cx("PrismaneCardFooter-root", className)}
         data-testid="prismane-card-footer"
         ref={ref}
         {...props}

--- a/src/components/Card/CardHeader/CardHeader.tsx
+++ b/src/components/Card/CardHeader/CardHeader.tsx
@@ -4,7 +4,7 @@ import React, { forwardRef } from "react";
 // Components
 import Flex, { FlexProps } from "@components/Flex";
 // Utils
-import { strip, fr } from "@utils";
+import { cx, fr } from "@utils";
 
 export type CardHeaderProps = FlexProps;
 
@@ -15,9 +15,7 @@ const CardHeader = forwardRef<HTMLDivElement, CardHeaderProps>(
         of="hidden"
         w="100%"
         mb={fr(2)}
-        className={strip(
-          `${className ? className : ""} PrismaneCardHeader-root`
-        )}
+        className={cx("PrismaneCardHeader-root", className)}
         data-testid="prismane-card-header"
         ref={ref}
         {...props}

--- a/src/components/Center/Center.tsx
+++ b/src/components/Center/Center.tsx
@@ -6,7 +6,7 @@ import Flex, { FlexProps } from "@components/Flex";
 // Types
 import { Versatile, PrismaneVersatile, PrismaneVersatileRef } from "@types";
 // Utils
-import { strip } from "@utils";
+import { cx } from "@utils";
 
 export type CenterProps<E extends Versatile = "div"> = PrismaneVersatile<
   E,
@@ -29,7 +29,7 @@ const Center: CenterComponent = forwardRef(
         as={Component}
         justify="center"
         align="center"
-        className={strip(`${className ? className : ""} PrismaneCenter-root`)}
+        className={cx("PrismaneCenter-root", className)}
         data-testid="prismane-center"
         ref={ref}
         {...props}

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -11,7 +11,7 @@ import Hidden from "@components/Hidden";
 // Types
 import { PrismaneFieldComponent, PrismaneProps } from "@types";
 // Utils
-import { strip, variants, fr } from "@utils";
+import { cx, variants, fr } from "@utils";
 
 export type CheckboxProps = PrismaneProps<
   { indeterminate?: boolean; icon?: ReactNode },
@@ -83,13 +83,10 @@ const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
               aspectRatio: 1,
               ...sx,
             }}
-            className={strip(
-              `${className ? className : ""} ${
-                field.value ? "PrismaneCheckbox-active" : ""
-              } ${
-                indeterminate ? "PrismaneCheckbox-indeterminate" : ""
-              } PrismaneCheckbox-root`
-            )}
+            className={cx("PrismaneCheckbox-root", className, {
+              "PrismaneCheckbox-active": field.value,
+              "PrismaneCheckbox-indeterminate": indeterminate,
+            })}
             {...rest}
           >
             <Hidden>

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -9,7 +9,7 @@ import Text from "@components/Text";
 // Types
 import { PrismaneColors, PrismaneBreakpoints, PrismaneProps } from "@types";
 // Utils
-import { strip, variants, fr } from "@utils";
+import { cx, variants, fr } from "@utils";
 
 export type ChipProps = PrismaneProps<
   {
@@ -67,11 +67,10 @@ const Chip = forwardRef<HTMLDivElement, ChipProps>(
           gap: fr(1.5),
           ...sx,
         }}
-        className={strip(
-          `${
-            className ? className : ""
-          } PrismaneChip-root-${size} PrismaneChip-root-${color} PrismaneChip-root`
-        )}
+        className={cx("PrismaneChip-root", className, {
+          [`PrismaneChip-root-${size}`]: true,
+          [`PrismaneChip-root-${color}`]: true,
+        })}
         data-testid="prismane-chip"
         ref={ref}
         {...props}

--- a/src/components/Circle/Circle.tsx
+++ b/src/components/Circle/Circle.tsx
@@ -12,7 +12,7 @@ import {
   PrismaneProps,
 } from "@types";
 // Utils
-import { strip } from "@utils";
+import { cx } from "@utils";
 
 export type CircleProps<E extends Versatile = "div"> = PrismaneVersatile<
   E,
@@ -41,7 +41,7 @@ const Circle: CircleComponent = forwardRef(
         w={size}
         h={size}
         br="100%"
-        className={strip(`${className ? className : ""} PrismaneCircle-root`)}
+        className={cx("PrismaneCircle-root", className)}
         data-testid="prismane-circle"
         ref={ref}
         {...props}

--- a/src/components/CloseButton/CloseButton.tsx
+++ b/src/components/CloseButton/CloseButton.tsx
@@ -5,12 +5,21 @@ import { X } from "@phosphor-icons/react";
 // Components
 import ActionButton, { ActionButtonProps } from "@components/ActionButton";
 // Utils
-import { variants } from "@utils";
+import { cx, variants } from "@utils";
 
 export type CloseButtonProps = ActionButtonProps;
 
 const CloseButton = forwardRef<any, CloseButtonProps>(
-  ({ size = "base", variant = "secondary", color = "base", ...props }, ref) => {
+  (
+    {
+      size = "base",
+      variant = "secondary",
+      color = "base",
+      className,
+      ...props
+    },
+    ref
+  ) => {
     return (
       <ActionButton
         color={color}
@@ -28,6 +37,11 @@ const CloseButton = forwardRef<any, CloseButtonProps>(
             weight="bold"
           />
         }
+        className={cx("PrismaneCloseButton-root", className, {
+          [`PrismaneCloseButton-${size}`]: true,
+          [`PrismaneCloseButton-${color}`]: true,
+          [`PrismaneCloseButton-${variant}`]: true,
+        })}
         ref={ref}
         {...props}
       />

--- a/src/components/Collapse/Collapse.tsx
+++ b/src/components/Collapse/Collapse.tsx
@@ -7,7 +7,7 @@ import Box from "@components/Box";
 // Types
 import { PrismaneProps } from "@types";
 // Utils
-import { strip } from "@utils";
+import { cx } from "@utils";
 
 export type CollapseProps = PrismaneProps<
   {
@@ -22,11 +22,9 @@ const Collapse = forwardRef<HTMLDivElement, CollapseProps>(
 
     return (
       <Animation
-        className={strip(
-          `${className ? className : ""} ${
-            open ? "PrismaneCollapse-root-open" : ""
-          } PrismaneCollapse-root`
-        )}
+        className={cx("PrismaneCollapse-root", className, {
+          "PrismaneCollapse-root-open": open,
+        })}
         of="hidden"
         animation={{
           in: {

--- a/src/components/ColorField/ColorField.tsx
+++ b/src/components/ColorField/ColorField.tsx
@@ -13,7 +13,7 @@ import { PRISMANE_DEFAULT_COLORS_MAP } from "@/constants";
 // Types
 import { PrismaneColors, PrismaneProps } from "@types";
 // Utils
-import { strip, fr } from "@utils";
+import { cx, fr } from "@utils";
 
 export type ColorFieldProps = PrismaneProps<
   {
@@ -88,9 +88,7 @@ const ColorField = forwardRef<
           },
           ...sx,
         }}
-        className={strip(
-          `${className ? className : ""} PrismaneColorField-root`
-        )}
+        className={cx("PrismaneColorField-root", className)}
         data-testid="prismane-color-field"
         ref={ref}
         {...props}

--- a/src/components/Container/Container.tsx
+++ b/src/components/Container/Container.tsx
@@ -6,7 +6,7 @@ import Flex, { FlexProps } from "@components/Flex";
 // Types
 import { PrismaneBreakpoints, PrismaneProps } from "@types";
 // Utils
-import { strip } from "@utils";
+import { cx } from "@utils";
 
 export type ContainerProps = PrismaneProps<
   {
@@ -32,11 +32,9 @@ const Container = forwardRef<HTMLDivElement, ContainerProps>(
         direction="column"
         maw={maxSize}
         grow
-        className={strip(
-          `${
-            className ? className : ""
-          } PrismaneContainer-root-${maxSize} PrismaneContainer-root`
-        )}
+        className={cx("PrismaneContainer-root", className, {
+          [`PrismaneContainer-root-${maxSize}`]: true,
+        })}
         data-testid="prismane-container"
         ref={ref}
         {...props}

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -15,7 +15,7 @@ import { DialogContextProvider } from "./DialogContext";
 // Types
 import { PrismaneWithInternal, PrismanePositions, PrismaneProps } from "@types";
 // Utils
-import { strip, fr, variants } from "@utils";
+import { cx, fr, variants } from "@utils";
 
 // Internal Components
 import DialogHeader, { DialogHeaderProps } from "./DialogHeader";
@@ -154,11 +154,9 @@ const Dialog = forwardRef<HTMLDivElement, DialogProps>(
                 left: "slide-left",
                 "left-end": "slide-left",
               })}
-              className={strip(
-                `${className ? className : ""} ${
-                  open ? "PrismaneDialog-root-open" : ""
-                } PrismaneDialog-root`
-              )}
+              className={cx("PrismaneDialog-root", className, {
+                "PrismaneDialog-root-open": open,
+              })}
               data-testid="prismane-dialog"
               ref={ref}
               shadow

--- a/src/components/Dialog/DialogFooter/DialogFooter.tsx
+++ b/src/components/Dialog/DialogFooter/DialogFooter.tsx
@@ -4,7 +4,7 @@ import React, { forwardRef } from "react";
 // Components
 import Flex, { FlexProps } from "@components/Flex";
 // Utils
-import { strip, fr } from "@utils";
+import { cx, fr } from "@utils";
 
 export type DialogFooterProps = FlexProps;
 
@@ -15,9 +15,7 @@ const DialogFooter = forwardRef<HTMLDivElement, DialogFooterProps>(
         of="hidden"
         w="100%"
         mt={fr(4)}
-        className={strip(
-          `${className ? className : ""} PrismaneDialogFooter-root`
-        )}
+        className={cx("PrismaneDialogFooter-root", className)}
         data-testid="prismane-dialog-footer"
         ref={ref}
         {...props}

--- a/src/components/Dialog/DialogHeader/DialogHeader.tsx
+++ b/src/components/Dialog/DialogHeader/DialogHeader.tsx
@@ -7,7 +7,7 @@ import CloseButton from "@components/CloseButton";
 // Context
 import { useDialogContext } from "../DialogContext";
 // Utils
-import { strip, fr } from "@utils";
+import { cx, fr } from "@utils";
 
 export type DialogHeaderProps = FlexProps;
 
@@ -21,9 +21,7 @@ const DialogHeader = forwardRef<HTMLDivElement, DialogHeaderProps>(
         justify="between"
         w="100%"
         mb={fr(2)}
-        className={strip(
-          `${className ? className : ""} PrismaneDialogHeader-root`
-        )}
+        className={cx("PrismaneDialogHeader-root", className)}
         data-testid="prismane-dialog-header"
         ref={ref}
         {...props}

--- a/src/components/Divider/Divider.tsx
+++ b/src/components/Divider/Divider.tsx
@@ -6,7 +6,7 @@ import Flex, { FlexProps } from "@components/Flex";
 // Types
 import { PrismaneProps, PrismaneBreakpoints } from "@types";
 // Utils
-import { strip, variants } from "@utils";
+import { cx, variants } from "@utils";
 
 export type DividerProps = PrismaneProps<
   {
@@ -70,7 +70,7 @@ const Divider = forwardRef<HTMLDivElement, DividerProps>(
         }
         bs="border-box"
         bdc={(theme) => (theme.mode === "dark" ? ["base", 700] : ["base", 300])}
-        className={strip(`${className ? className : ""} PrismaneDivider-root`)}
+        className={cx("PrismaneDivider-root", className)}
         grow
         data-testid="prismane-divider"
         ref={ref}

--- a/src/components/Drawer/Drawer.tsx
+++ b/src/components/Drawer/Drawer.tsx
@@ -19,7 +19,7 @@ import {
   PrismaneProps,
 } from "@types";
 // Utils
-import { strip, variants, dual, fr } from "@utils";
+import { cx, variants, dual, fr } from "@utils";
 // Internal Components
 import DrawerHeader, { DrawerHeaderProps } from "./DrawerHeader";
 import DrawerFooter, { DrawerFooterProps } from "./DrawerFooter";
@@ -145,11 +145,9 @@ const Drawer = forwardRef<HTMLDivElement, DrawerProps>(
               onClick={(e: any) => {
                 e.stopPropagation();
               }}
-              className={strip(
-                `${className ? className : ""} ${
-                  open ? "PrismaneDrawer-root-open" : ""
-                } PrismaneDrawer-root`
-              )}
+              className={cx("PrismaneDrawer-root", className, {
+                "PrismaneDrawer-root-open": open,
+              })}
               data-testid="prismane-drawer"
               ref={ref}
               {...props}

--- a/src/components/Drawer/DrawerFooter/DrawerFooter.tsx
+++ b/src/components/Drawer/DrawerFooter/DrawerFooter.tsx
@@ -4,7 +4,7 @@ import React, { forwardRef } from "react";
 // Components
 import Flex, { FlexProps } from "@components/Flex";
 // Utils
-import { strip, fr } from "@utils";
+import { cx, fr } from "@utils";
 
 export type DrawerFooterProps = FlexProps;
 
@@ -17,9 +17,7 @@ const DrawerFooter = forwardRef<HTMLDivElement, DrawerFooterProps>(
         mt="auto"
         pt={fr(6)}
         self="end"
-        className={strip(
-          `${className ? className : ""} PrismaneDrawerFooter-root`
-        )}
+        className={cx("PrismaneDrawerFooter-root", className)}
         data-testid="prismane-drawer-footer"
         ref={ref}
         {...props}

--- a/src/components/Drawer/DrawerHeader/DrawerHeader.tsx
+++ b/src/components/Drawer/DrawerHeader/DrawerHeader.tsx
@@ -7,7 +7,7 @@ import CloseButton from "@components/CloseButton";
 // Context
 import { useDrawerContext } from "../DrawerContext";
 // Utils
-import { strip, fr } from "@utils";
+import { cx, fr } from "@utils";
 
 export type DrawerHeaderProps = FlexProps;
 
@@ -21,9 +21,7 @@ const DrawerHeader = forwardRef<HTMLDivElement, DrawerHeaderProps>(
         justify="between"
         w="100%"
         mb={fr(3)}
-        className={strip(
-          `${className ? className : ""} PrismaneDrawerHeader-root`
-        )}
+        className={cx("PrismaneDrawerHeader-root", className)}
         data-testid="prismane-drawer-header"
         ref={ref}
         {...props}

--- a/src/components/Field/Field.tsx
+++ b/src/components/Field/Field.tsx
@@ -20,7 +20,7 @@ import {
 import { usePrismaneColor } from "../PrismaneProvider";
 import useFieldProps from "./useFieldProps";
 // Utils
-import { strip, variants, fr } from "@utils";
+import { cx, variants, fr } from "@utils";
 
 // Internal Components
 import FieldError, { FieldErrorProps } from "./FieldError";
@@ -142,11 +142,10 @@ const Field = forwardRef(
         pe={disabled && "none"}
         op={disabled ? 0.4 : 1}
         of="hidden"
-        className={strip(
-          `${
-            className ? className : ""
-          } PrismaneField-root-${size} PrismaneField-root-${variant} PrismaneField-root`
-        )}
+        className={cx("PrismaneField-root", className, {
+          [`PrismaneField-root-${size}`]: true,
+          [`PrismaneField-root-${variant}`]: true,
+        })}
         {...rest}
       >
         {icon && (
@@ -192,7 +191,7 @@ const Field = forwardRef(
                   : getColor("base", 800),
             }),
           }}
-          className={strip(`${className ? className : ""} PrismaneField-field`)}
+          className={cx("PrismaneField-field", className)}
           data-testid="prismane-field"
           ref={ref}
           {...field}

--- a/src/components/Field/FieldAddon/FieldAddon.tsx
+++ b/src/components/Field/FieldAddon/FieldAddon.tsx
@@ -7,7 +7,7 @@ import Flex, { FlexProps } from "@components/Flex";
 // Types
 import { PrismaneBreakpoints, PrismaneProps } from "@types";
 // Utils
-import { strip, variants, fr } from "@utils";
+import { cx, variants, fr } from "@utils";
 
 export type FieldAddonProps = PrismaneProps<
   {
@@ -37,9 +37,7 @@ const FieldAddon = forwardRef<HTMLDivElement, FieldAddonProps>(
         })}
         align="center"
         justify="center"
-        className={strip(
-          `${className ? className : ""} PrismaneFieldAddon-root`
-        )}
+        className={cx("PrismaneFieldAddon-root", className)}
         sx={{
           order: position === "right" ? 1 : -1,
           ...sx,

--- a/src/components/Field/FieldError/FieldError.tsx
+++ b/src/components/Field/FieldError/FieldError.tsx
@@ -7,7 +7,7 @@ import Animation, { AnimationProps } from "@components/Animation";
 // Types
 import { PrismaneBreakpoints, PrismaneProps } from "@types";
 // Utils
-import { strip, variants, fr } from "@utils";
+import { cx, variants, fr } from "@utils";
 
 export type FieldErrorProps = PrismaneProps<
   {
@@ -43,9 +43,7 @@ const FieldError = forwardRef<HTMLDivElement, FieldErrorProps>(
               lg: "md",
             })}
             cl="red"
-            className={strip(
-              `${className ? className : ""} PrismaneFieldError-root`
-            )}
+            className={cx("PrismaneFieldError-root", className)}
             data-testid="prismane-field-error"
             ref={ref}
             {...props}

--- a/src/components/Field/FieldLabel/FieldLabel.tsx
+++ b/src/components/Field/FieldLabel/FieldLabel.tsx
@@ -6,7 +6,7 @@ import Text, { TextProps } from "@components/Text";
 // Types
 import { PrismaneBreakpoints, PrismaneProps } from "@types";
 // Utils
-import { strip, variants } from "@utils";
+import { cx, variants } from "@utils";
 
 export type FieldLabelProps = PrismaneProps<
   {
@@ -40,9 +40,7 @@ const FieldLabel = forwardRef<HTMLLabelElement, FieldLabelProps>(
               justifyContent: "space-between",
               ...sx,
             }}
-            className={strip(
-              `${className ? className : ""} PrismaneFieldLabel-root`
-            )}
+            className={cx("PrismaneFieldLabel-root", className)}
             data-testid="prismane-field-label"
             ref={ref}
             {...props}

--- a/src/components/Field/FieldWrapper/FieldWrapper.tsx
+++ b/src/components/Field/FieldWrapper/FieldWrapper.tsx
@@ -4,7 +4,7 @@ import React, { forwardRef } from "react";
 // Components
 import Flex, { FlexProps } from "@components/Flex";
 // Utils
-import { strip, fr } from "@utils";
+import { cx, fr } from "@utils";
 
 export type FieldWrapperProps = FlexProps;
 
@@ -15,9 +15,7 @@ const FieldWrapper = forwardRef<HTMLDivElement, FieldWrapperProps>(
         w="100%"
         direction="column"
         gap={fr(2)}
-        className={strip(
-          `${className ? className : ""} PrismaneFieldWrapper-root`
-        )}
+        className={cx("PrismaneFieldWrapper-root", className)}
         data-testid="prismane-field-wrapper"
         ref={ref}
         {...props}

--- a/src/components/Flex/Flex.tsx
+++ b/src/components/Flex/Flex.tsx
@@ -11,7 +11,7 @@ import {
   PrismaneProps,
 } from "@types";
 // Utils
-import { strip, variants } from "@utils";
+import { cx, variants } from "@utils";
 
 export type FlexProps<E extends Versatile = "div"> = PrismaneVersatile<
   E,
@@ -100,7 +100,7 @@ const Flex: FlexComponent = forwardRef(
           gap: gap,
           ...sx,
         }}
-        className={strip(`${className ? className : ""} PrismaneFlex-root`)}
+        className={cx("PrismaneFlex-root", className)}
         data-testid="prismane-flex"
         ref={ref}
         {...props}

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -4,7 +4,7 @@ import React, { forwardRef } from "react";
 // Components
 import Flex, { FlexProps } from "@components/Flex";
 // Utils
-import { strip } from "@utils";
+import { cx } from "@utils";
 
 export type FooterProps = FlexProps<"footer">;
 
@@ -14,7 +14,7 @@ const Footer = forwardRef<HTMLElement, FooterProps>(
       <Flex
         as="footer"
         grow
-        className={strip(`${className ? className : ""} PrismaneFooter-root`)}
+        className={cx("PrismaneFooter-root", className)}
         data-testid="prismane-footer"
         ref={ref}
         {...props}

--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -4,7 +4,7 @@ import React, { forwardRef } from "react";
 // Components
 import Box, { BoxProps } from "@components/Box";
 // Utils
-import { strip, fr } from "@utils";
+import { cx, fr } from "@utils";
 
 export type FormProps = BoxProps<"form">;
 
@@ -14,7 +14,7 @@ const Form = forwardRef<HTMLFormElement, FormProps>(
       <Box
         as="form"
         dp="flex"
-        className={strip(`${className ? className : ""} PrismaneForm-root`)}
+        className={cx("PrismaneForm-root", className)}
         onSubmit={onSubmit}
         onReset={onReset}
         sx={{

--- a/src/components/Gradient/Gradient.tsx
+++ b/src/components/Gradient/Gradient.tsx
@@ -16,7 +16,7 @@ import {
   PrismaneShades,
 } from "@types";
 // Utils
-import { strip } from "@utils";
+import { cx } from "@utils";
 
 export type GradientProps<E extends Versatile = "div"> = PrismaneVersatile<
   E,
@@ -63,7 +63,7 @@ const Gradient: GradientComponent = forwardRef(
     return (
       <Box
         as={Component}
-        className={strip(`${className ? className : ""} PrismaneGradient-root`)}
+        className={cx("PrismaneGradient-root", className)}
         bg="transparent"
         sx={{
           background: `linear-gradient(${deg}deg, ${getColorStyle(

--- a/src/components/Grid/Grid.tsx
+++ b/src/components/Grid/Grid.tsx
@@ -6,7 +6,7 @@ import Box, { BoxProps } from "@components/Box";
 // Types
 import { PrismaneProps, PrismaneWithInternal } from "@types";
 // Utils
-import { strip, variants } from "@utils";
+import { cx, variants } from "@utils";
 
 // Internal Components
 import GridItem, { GridItemProps } from "./GridItem";
@@ -73,7 +73,7 @@ const Grid = forwardRef<HTMLDivElement, GridProps>(
   ) => {
     return (
       <Box
-        className={strip(`${className ? className : ""} PrismaneGrid-root`)}
+        className={cx("PrismaneGrid-root", className)}
         dp="grid"
         sx={{
           gap: gap,

--- a/src/components/Grid/GridItem/GridItem.tsx
+++ b/src/components/Grid/GridItem/GridItem.tsx
@@ -6,7 +6,7 @@ import Flex, { FlexProps } from "@components/Flex";
 // Types
 import { PrismaneProps } from "@types";
 // Utils
-import { strip, variants } from "@utils";
+import { cx, variants } from "@utils";
 
 export type GridItemProps = PrismaneProps<
   {
@@ -56,7 +56,7 @@ const GridItem = forwardRef<HTMLDivElement, GridItemProps>(
     return (
       <Flex
         dp="grid"
-        className={strip(`${className ? className : ""} PrismaneGridItem-root`)}
+        className={cx("PrismaneGridItem-root", className)}
         sx={{
           gap,
           gridArea: area,

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -4,7 +4,7 @@ import React, { forwardRef } from "react";
 // Components
 import Flex, { FlexProps } from "@components/Flex";
 // Utils
-import { strip } from "@utils";
+import { cx } from "@utils";
 
 export type HeaderProps = FlexProps<"header">;
 
@@ -15,7 +15,7 @@ const Header = forwardRef<HTMLElement, HeaderProps>(
         as="header"
         align="center"
         grow
-        className={strip(`${className ? className : ""} PrismaneHeader-root`)}
+        className={cx("PrismaneHeader-root", className)}
         data-testid="prismane-header"
         ref={ref}
         {...props}

--- a/src/components/Hidden/Hidden.tsx
+++ b/src/components/Hidden/Hidden.tsx
@@ -4,7 +4,7 @@ import React, { forwardRef } from "react";
 // Components
 import Box, { BoxProps } from "@components/Box";
 // Utils
-import { strip } from "@utils";
+import { cx } from "@utils";
 
 export type HiddenProps = BoxProps;
 
@@ -17,7 +17,7 @@ const Hidden = forwardRef<HTMLSpanElement, HiddenProps>(
         h={0}
         of="hidden"
         dp="block"
-        className={strip(`${className ? className : ""} PrismaneHidden-root`)}
+        className={cx("PrismaneHidden-root", className)}
         data-testid="prismane-hidden"
         ref={ref}
         {...props}

--- a/src/components/Hide/Hide.tsx
+++ b/src/components/Hide/Hide.tsx
@@ -8,7 +8,7 @@ import useMediaQuery from "@hooks/useMediaQuery";
 // Types
 import { PrismaneBreakpoints, PrismaneProps } from "@types";
 // Utils
-import { strip, dual, fr } from "@utils";
+import { cx, dual, fr } from "@utils";
 
 export type HideProps = PrismaneProps<
   {
@@ -32,7 +32,7 @@ const Hide = forwardRef<HTMLDivElement, HideProps>(
     return (
       <Box
         dp={hidden ? "none" : "flex"}
-        className={strip(`${className ? className : ""} PrismaneHide-root`)}
+        className={cx("PrismaneHide-root", className)}
         ref={ref}
         data-testid="prismane-hide"
         {...props}

--- a/src/components/Highlight/Highlight.tsx
+++ b/src/components/Highlight/Highlight.tsx
@@ -6,7 +6,7 @@ import Box, { BoxProps } from "@components/Box";
 // Types
 import { Versatile, PrismaneVersatile, PrismaneVersatileRef } from "@types";
 // Utils
-import { strip, fr } from "@utils";
+import { cx, fr } from "@utils";
 
 export type HighlightProps<E extends Versatile = "mark"> = PrismaneVersatile<
   E,
@@ -32,9 +32,7 @@ const Highlight: HighlightComponent = forwardRef(
         }
         cl={(theme) => (theme.mode === "dark" ? "white" : ["base", 900])}
         p={fr(1)}
-        className={strip(
-          `${className ? className : ""} PrismaneHighlight-root`
-        )}
+        className={cx("PrismaneHighlight-root", className)}
         data-testid="prismane-highlight"
         ref={ref}
         {...props}

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -6,7 +6,7 @@ import Square, { SquareProps } from "@components/Square";
 // Types
 import { PrismaneBreakpoints, PrismaneProps } from "@types";
 // Utils
-import { strip, dual, fr } from "@utils";
+import { cx, dual, fr } from "@utils";
 
 export type IconProps = PrismaneProps<
   {
@@ -26,11 +26,9 @@ const Icon = forwardRef<HTMLDivElement, IconProps>(
           md: fr(7),
           lg: fr(8),
         })}
-        className={strip(
-          `${
-            className ? className : ""
-          } PrismaneIcon-root-${size} PrismaneIcon-root`
-        )}
+        className={cx("PrismaneIcon-root", className, {
+          [`PrismaneIcon-root-${size}`]: true,
+        })}
         sx={{
           fontSize: dual(size, {
             xs: fr(4),

--- a/src/components/Image/Image.tsx
+++ b/src/components/Image/Image.tsx
@@ -6,7 +6,7 @@ import Box, { BoxProps } from "@components/Box";
 // Types
 import { PrismaneProps } from "@types";
 // Utils
-import { strip } from "@utils";
+import { cx } from "@utils";
 
 export type ImageProps = PrismaneProps<
   {
@@ -32,7 +32,7 @@ const Image = forwardRef<HTMLImageElement, ImageProps>(
           objectFit: fit,
           ...sx,
         }}
-        className={strip(`${className ? className : ""} PrismaneImage-root`)}
+        className={cx("PrismaneImage-root", className)}
         data-testid="prismane-image"
         ref={ref}
         {...props}

--- a/src/components/Key/Key.tsx
+++ b/src/components/Key/Key.tsx
@@ -4,7 +4,7 @@ import React, { forwardRef } from "react";
 // Components
 import Box, { BoxProps } from "@components/Box";
 // Utils
-import { strip, fr } from "@utils";
+import { cx, fr } from "@utils";
 
 export type KeyProps = BoxProps<"kbd">;
 
@@ -22,7 +22,7 @@ const Key = forwardRef<HTMLDivElement, KeyProps>(
         bdbw={3}
         bdc={(theme) => (theme.mode === "dark" ? ["base", 600] : ["base", 400])}
         cl={(theme) => (theme.mode === "dark" ? ["base", 200] : ["base", 700])}
-        className={strip(`${className ? className : ""} PrismaneKey-root`)}
+        className={cx("PrismaneKey-root", className)}
         data-testid="prismane-key"
         ref={ref}
         {...props}

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -11,7 +11,7 @@ import {
   PrismaneProps,
 } from "@types";
 // Utils
-import { strip, variants, fr } from "@utils";
+import { cx, variants, fr } from "@utils";
 
 export type LinkProps<E extends Versatile = "a"> = PrismaneVersatile<
   E,
@@ -63,7 +63,7 @@ const Link: LinkComponent = forwardRef(
           }),
           ...sx,
         }}
-        className={strip(`${className ? className : ""} PrismaneLink-root`)}
+        className={cx("PrismaneLink-root", className)}
         onClick={async (e: any) => {
           if (before) {
             e.preventDefault();

--- a/src/components/List/List.tsx
+++ b/src/components/List/List.tsx
@@ -11,7 +11,7 @@ import {
   PrismaneVersatileRef,
 } from "@types";
 // Utils
-import { strip } from "@utils";
+import { cx } from "@utils";
 
 // Internal Components
 import ListUnordered, { ListUnorderedProps } from "./ListUnordered";
@@ -43,7 +43,7 @@ const List = forwardRef(
         as={Component}
         direction="column"
         gap={gap}
-        className={strip(`${className ? className : ""} PrismaneList-root`)}
+        className={cx("PrismaneList-root", className)}
         sx={{ listStyleType: "none", ...sx }}
         data-testid="prismane-list"
         ref={ref}

--- a/src/components/List/ListIcon/ListIcon.tsx
+++ b/src/components/List/ListIcon/ListIcon.tsx
@@ -4,7 +4,7 @@ import React, { forwardRef } from "react";
 // Components
 import Icon, { IconProps } from "@components/Icon";
 // Utils
-import { strip } from "@utils";
+import { cx } from "@utils";
 
 export type ListIconProps = IconProps;
 
@@ -12,7 +12,7 @@ const ListIcon = forwardRef<HTMLDivElement, ListIconProps>(
   ({ children, className, ...props }, ref) => {
     return (
       <Icon
-        className={strip(`${className ? className : ""} PrismaneListIcon-root`)}
+        className={cx("PrismaneListIcon-root", className)}
         data-testid="prismane-list-icon"
         ref={ref as any}
         {...props}

--- a/src/components/List/ListItem/ListItem.tsx
+++ b/src/components/List/ListItem/ListItem.tsx
@@ -5,7 +5,7 @@ import React, { forwardRef } from "react";
 import Flex, { FlexProps } from "@components/Flex";
 import Box from "@components/Box";
 // Utils
-import { strip, fr } from "@utils";
+import { cx, fr } from "@utils";
 
 export type ListItemProps = FlexProps<"li">;
 
@@ -19,9 +19,7 @@ const ListItem = forwardRef<HTMLLIElement, ListItemProps>(
         <Flex
           align="center"
           gap={gap}
-          className={strip(
-            `${className ? className : ""} PrismaneListItem-root`
-          )}
+          className={cx("PrismaneListItem-root", className)}
           data-testid="prismane-list-item"
           ref={ref}
           {...props}

--- a/src/components/List/ListOrdered/ListOrdered.tsx
+++ b/src/components/List/ListOrdered/ListOrdered.tsx
@@ -4,7 +4,7 @@ import React, { forwardRef } from "react";
 // Components
 import List, { ListProps } from "@components/List";
 // Utils
-import { strip } from "@utils";
+import { cx } from "@utils";
 
 export type ListOrderedProps = ListProps<"ol">;
 
@@ -18,9 +18,7 @@ const ListOrdered = forwardRef<HTMLOListElement, ListOrderedProps>(
           listStyleType: "revert",
           ...sx,
         }}
-        className={strip(
-          `${className ? className : ""} PrismaneListOrdered-root`
-        )}
+        className={cx("PrismaneListOrdered-root", className)}
         data-testid="prismane-list-ordered"
         ref={ref}
         {...props}

--- a/src/components/List/ListUnordered/ListUnordered.tsx
+++ b/src/components/List/ListUnordered/ListUnordered.tsx
@@ -4,7 +4,7 @@ import React, { forwardRef } from "react";
 // Components
 import List, { ListProps } from "@components/List";
 // Utils
-import { strip } from "@utils";
+import { cx } from "@utils";
 
 export type ListUnorderedProps = ListProps;
 
@@ -18,9 +18,7 @@ const ListUnordered = forwardRef<HTMLUListElement, ListUnorderedProps>(
           listStyleType: "revert",
           ...sx,
         }}
-        className={strip(
-          `${className ? className : ""} PrismaneListUnordered-root`
-        )}
+        className={cx("PrismaneListUnordered-root", className)}
         data-testid="prismane-list-unordered"
         ref={ref}
         {...props}

--- a/src/components/Main/Main.tsx
+++ b/src/components/Main/Main.tsx
@@ -4,7 +4,7 @@ import React, { forwardRef } from "react";
 // Components
 import Flex, { FlexProps } from "@components/Flex";
 // Utils
-import { strip, fr } from "@utils";
+import { cx, fr } from "@utils";
 
 export type MainProps = FlexProps<"main">;
 
@@ -16,7 +16,7 @@ const Main = forwardRef<HTMLElement, MainProps>(
         px={fr(5)}
         py={fr(3)}
         grow
-        className={strip(`${className ? className : ""} PrismaneMain-root`)}
+        className={cx("PrismaneMain-root", className)}
         data-testid="prismane-main"
         ref={ref}
         {...props}

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -10,7 +10,7 @@ import useAnimation from "@hooks/useAnimation";
 // Types
 import { PrismaneProps, PrismaneWithInternal } from "@types";
 // Utils
-import { strip, fr } from "@utils";
+import { cx, fr } from "@utils";
 
 // Internal Components
 import MenuItem, { MenuItemProps } from "./MenuItem";
@@ -51,11 +51,9 @@ const Menu = forwardRef<HTMLDivElement, MenuProps>(
             animated={animating}
             duration={duration}
             timing={timing}
-            className={strip(
-              `${className ? className : ""} ${
-                open ? "PrismaneMenu-root-open" : ""
-              } PrismaneMenu-root`
-            )}
+            className={cx("PrismaneMenu-root", className, {
+              "PrismaneMenu-root-open": open,
+            })}
             data-testid="prismane-menu"
             role="menu"
             ref={ref}

--- a/src/components/Menu/MenuIcon/MenuIcon.tsx
+++ b/src/components/Menu/MenuIcon/MenuIcon.tsx
@@ -4,7 +4,7 @@ import React, { forwardRef } from "react";
 // Components
 import Icon, { IconProps } from "@components/Icon";
 // Utils
-import { strip } from "@utils";
+import { cx } from "@utils";
 
 export type MenuIconProps = Omit<IconProps, "size">;
 
@@ -12,7 +12,7 @@ const MenuIcon = forwardRef<HTMLDivElement, MenuIconProps>(
   ({ children, className, ...props }, ref) => {
     return (
       <Icon
-        className={strip(`${className ? className : ""} PrismaneMenuIcon-root`)}
+        className={cx("PrismaneMenuIcon-root", className)}
         data-testid="prismane-menu-icon"
         ref={ref as any}
         {...props}

--- a/src/components/Menu/MenuItem/MenuItem.tsx
+++ b/src/components/Menu/MenuItem/MenuItem.tsx
@@ -5,7 +5,7 @@ import React, { forwardRef } from "react";
 import Flex, { FlexProps } from "@components/Flex";
 import Transition, { TransitionProps } from "@components/Transition";
 // Utils
-import { strip, fr } from "@utils";
+import { cx, fr } from "@utils";
 // Types
 import { PrismaneColors, PrismaneProps } from "@types";
 
@@ -43,11 +43,9 @@ const MenuItem = forwardRef<HTMLDivElement, MenuItemProps>(
         br="base"
         cs="pointer"
         bs="border-box"
-        className={strip(
-          `${
-            className ? className : ""
-          } PrismaneMenuItem-root-${color} PrismaneMenuItem-root`
-        )}
+        className={cx("PrismaneMenuItem-root", className, {
+          [`PrismaneMenuItem-root-${color}`]: true,
+        })}
         data-testid="prismane-menu-item"
         role="menuitem"
         ref={ref}

--- a/src/components/Menu/MenuLabel/MenuLabel.tsx
+++ b/src/components/Menu/MenuLabel/MenuLabel.tsx
@@ -4,7 +4,7 @@ import React, { forwardRef } from "react";
 // Components
 import Flex, { FlexProps } from "@components/Flex";
 // Utils
-import { strip, fr } from "@utils";
+import { cx, fr } from "@utils";
 // Types
 import { PrismaneColors, PrismaneProps } from "@types";
 
@@ -29,11 +29,9 @@ const MenuLabel = forwardRef<HTMLDivElement, MenuLabelProps>(
           },
           ...sx,
         }}
-        className={strip(
-          `${
-            className ? className : ""
-          } PrismaneMenuLabel-root-${color} PrismaneMenuLabel-root`
-        )}
+        className={cx("PrismaneMenuLabel-root", className, {
+          [`PrismaneMenuLabel-root-${color}`]: true,
+        })}
         data-testid="prismane-menu-label"
         ref={ref}
         {...props}

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -15,7 +15,7 @@ import { ModalContextProvider } from "./ModalContext";
 // Types
 import { PrismaneProps, PrismaneWithInternal } from "@types";
 // Utils
-import { strip, fr } from "@utils";
+import { cx, fr } from "@utils";
 
 // Internal Components
 import ModalHeader, { ModalHeaderProps } from "./ModalHeader";
@@ -83,11 +83,9 @@ const Modal = forwardRef<HTMLDivElement, ModalProps>(
               onClick={(e: any) => {
                 e.stopPropagation();
               }}
-              className={strip(
-                `${className ? className : ""} ${
-                  open ? "PrismaneModal-root-open" : ""
-                } PrismaneModal-root`
-              )}
+              className={cx("PrismaneModal-root", className, {
+                "PrismaneModal-root-open": open,
+              })}
               data-testid="prismane-modal"
               ref={ref}
               {...props}

--- a/src/components/Modal/ModalFooter/ModalFooter.tsx
+++ b/src/components/Modal/ModalFooter/ModalFooter.tsx
@@ -4,7 +4,7 @@ import React, { forwardRef } from "react";
 // Components
 import Flex, { FlexProps } from "@components/Flex";
 // Utils
-import { strip, fr } from "@utils";
+import { cx, fr } from "@utils";
 
 export type ModalFooterProps = FlexProps;
 
@@ -15,9 +15,7 @@ const ModalFooter = forwardRef<HTMLDivElement, ModalFooterProps>(
         of="hidden"
         w="100%"
         mt={fr(6)}
-        className={strip(
-          `${className ? className : ""} PrismaneModalFooter-root`
-        )}
+        className={cx("PrismaneModalFooter-root", className)}
         data-testid="prismane-modal-footer"
         ref={ref}
         {...props}

--- a/src/components/Modal/ModalHeader/ModalHeader.tsx
+++ b/src/components/Modal/ModalHeader/ModalHeader.tsx
@@ -7,7 +7,7 @@ import CloseButton from "@components/CloseButton";
 // Context
 import { useModalContext } from "../ModalContext";
 // Utils
-import { strip, fr } from "@utils";
+import { cx, fr } from "@utils";
 
 export type ModalHeaderProps = FlexProps;
 
@@ -21,9 +21,7 @@ const ModalHeader = forwardRef<HTMLDivElement, ModalHeaderProps>(
         justify="between"
         w="100%"
         mb={fr(3)}
-        className={strip(
-          `${className ? className : ""} PrismaneModalHeader-root`
-        )}
+        className={cx("PrismaneModalHeader-root", className)}
         data-testid="prismane-modal-header"
         ref={ref}
         {...props}

--- a/src/components/NativeDateField/NativeDateField.tsx
+++ b/src/components/NativeDateField/NativeDateField.tsx
@@ -4,7 +4,7 @@ import React, { forwardRef } from "react";
 // Components
 import Field, { FieldProps, useFieldProps } from "@components/Field";
 // Utils
-import { strip } from "@utils";
+import { cx } from "@utils";
 
 export type NativeDateFieldProps = FieldProps;
 
@@ -28,9 +28,7 @@ const NativeDateField = forwardRef<
         py={0}
         size={size as any}
         error={error}
-        className={strip(
-          `${className ? className : ""} PrismaneNativeDateField-root`
-        )}
+        className={cx("PrismaneNativeDateField-root", className)}
         data-testid="prismane-native-date-field"
         ref={ref}
         {...field}

--- a/src/components/NativeSelectField/NativeSelectField.tsx
+++ b/src/components/NativeSelectField/NativeSelectField.tsx
@@ -7,7 +7,7 @@ import Text from "@components/Text";
 // Types
 import { PrismaneProps } from "@types";
 // Utils
-import { strip } from "@utils";
+import { cx } from "@utils";
 
 export type NativeSelectFieldProps = PrismaneProps<
   {
@@ -36,9 +36,7 @@ const NativeSelectField = forwardRef<
         py={0}
         size={size as any}
         error={error}
-        className={strip(
-          `${className ? className : ""} PrismaneNativeSelectField-root`
-        )}
+        className={cx("PrismaneNativeSelectField-root", className)}
         data-testid="prismane-native-select-field"
         ref={ref}
         {...field}

--- a/src/components/NumberField/NumberField.tsx
+++ b/src/components/NumberField/NumberField.tsx
@@ -11,7 +11,7 @@ import useEmulatedFieldChange from "@hooks/useEmulatedFieldChange";
 // Types
 import { PrismaneProps } from "@types";
 // Utils
-import { strip, fr } from "@utils";
+import { cx, fr } from "@utils";
 
 export type NumberFieldProps = PrismaneProps<
   {
@@ -115,9 +115,7 @@ const NumberField = forwardRef<
               </Transition>
             </Field.Addon>
           }
-          className={strip(
-            `${className ? className : ""} PrismaneNumberField-root`
-          )}
+          className={cx("PrismaneNumberField-root", className)}
           data-testid="prismane-number-field"
           ref={fieldRef}
           {...field}

--- a/src/components/Paper/Paper.tsx
+++ b/src/components/Paper/Paper.tsx
@@ -11,7 +11,7 @@ import {
   PrismaneProps,
 } from "@types";
 // Utils
-import { strip } from "@utils";
+import { cx } from "@utils";
 
 export type PaperProps<E extends Versatile = "div"> = PrismaneVersatile<
   E,
@@ -41,7 +41,7 @@ const Paper: PaperComponent = forwardRef(
         br="md"
         bg={(theme) => (theme.mode === "dark" ? ["base", 800] : "white")}
         bsh={shadow && "base"}
-        className={strip(`${className ? className : ""} PrismanePaper-root`)}
+        className={cx("PrismanePaper-root", className)}
         data-testid="prismane-paper"
         ref={ref}
         {...props}

--- a/src/components/PasswordField/PasswordField.tsx
+++ b/src/components/PasswordField/PasswordField.tsx
@@ -7,14 +7,14 @@ import Field, { FieldProps, useFieldProps } from "@components/Field";
 import Icon from "@components/Icon";
 import Transition from "@components/Transition";
 // Utils
-import { variants, fr } from "@utils";
+import { cx, variants, fr } from "@utils";
 
 export type PasswordFieldProps = FieldProps;
 
 const PasswordField = forwardRef<
   HTMLInputElement | HTMLTextAreaElement,
   PasswordFieldProps
->(({ label, error, size = "base", ...props }, ref) => {
+>(({ label, error, size = "base", className, ...props }, ref) => {
   const [rest, field] = useFieldProps(props);
 
   const [mutableType, setMutableType] = useState("password");
@@ -58,7 +58,7 @@ const PasswordField = forwardRef<
             </Transition>
           </Field.Addon>
         }
-        className="PrismanePasswordField-root"
+        className={cx("PrismanePasswordField-root", className)}
         data-testid="prismane-password-field"
         ref={ref}
         {...field}

--- a/src/components/PinField/PinField.tsx
+++ b/src/components/PinField/PinField.tsx
@@ -10,7 +10,7 @@ import useEmulatedFieldChange from "@hooks/useEmulatedFieldChange";
 // Types
 import { PrismaneProps } from "@types";
 // Utils
-import { fr } from "@utils";
+import { cx, fr } from "@utils";
 
 export type PinFieldProps = PrismaneProps<
   {
@@ -25,7 +25,15 @@ const PinField = forwardRef<
   PinFieldProps
 >(
   (
-    { size = "base", label, error, length = 4, masked = false, ...props },
+    {
+      size = "base",
+      label,
+      error,
+      length = 4,
+      masked = false,
+      className,
+      ...props
+    },
     ref
   ) => {
     const [rest, field] = useFieldProps(props);
@@ -130,6 +138,7 @@ const PinField = forwardRef<
                 },
                 aspectRatio: "1/1",
               }}
+              className={cx("PrismanePinField-root", className)}
               key={index}
               ref={(el: any) => (fieldRefs.current[index] = el) as any}
             />

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -11,7 +11,7 @@ import useOutsideClick from "@hooks/useOutsideClick";
 // Types
 import { PrismanePositions, PrismaneProps, PrismaneWithInternal } from "@types";
 // Utils
-import { strip } from "@utils";
+import { cx } from "@utils";
 
 // Internal Components
 import PopoverControl, { PopoverControlProps } from "./PopoverControl";
@@ -42,11 +42,9 @@ const Popover = forwardRef<HTMLDivElement, PopoverProps>(
         w="fit-content"
         h="fit-content"
         pos="relative"
-        className={strip(
-          `${
-            className ? className : ""
-          } PrismanePopover-root-${position} PrismanePopover-root`
-        )}
+        className={cx("PrismanePopover-root", className, {
+          [`PrismanePopover-root-${position}`]: true,
+        })}
         data-testid="prismane-popover"
         ref={boxRef}
         {...props}

--- a/src/components/Popover/PopoverControl/PopoverControl.tsx
+++ b/src/components/Popover/PopoverControl/PopoverControl.tsx
@@ -6,7 +6,7 @@ import Flex, { FlexProps } from "@components/Flex";
 // Context
 import { usePopoverContext } from "../PopoverContext";
 // Utils
-import { strip } from "@utils";
+import { cx } from "@utils";
 
 export type PopoverControlProps = FlexProps;
 
@@ -19,11 +19,9 @@ const PopoverControl = forwardRef<HTMLDivElement, PopoverControlProps>(
         onClick={() => {
           setOpen(!open);
         }}
-        className={strip(
-          `${className ? className : ""} ${
-            open ? "PrismanePopoverControl-root-open" : ""
-          } PrismanePopoverControl-root`
-        )}
+        className={cx("PrismanePopoverControl-root", className, {
+          "PrismanePopoverControl-root-open": open,
+        })}
         data-testid="prismane-popover-control"
         ref={ref}
         {...props}

--- a/src/components/Popover/PopoverPanel/PopoverPanel.tsx
+++ b/src/components/Popover/PopoverPanel/PopoverPanel.tsx
@@ -11,7 +11,7 @@ import useAnimation from "@hooks/useAnimation";
 import usePresence from "@hooks/usePresence";
 
 // Utils
-import { strip, variants, fr } from "@utils";
+import { cx, variants, fr } from "@utils";
 
 export type PopoverPanelProps = AnimationProps & PaperProps;
 
@@ -84,11 +84,9 @@ const PopoverPanel = forwardRef<HTMLDivElement, PopoverPanelProps>(
               whiteSpace: "nowrap",
               ...sx,
             }}
-            className={strip(
-              `${className ? className : ""} ${
-                open ? "PrismanePopoverPanel-root-open" : ""
-              } PrismanePopoverPanel-root`
-            )}
+            className={cx("PrismanePopoverPanel-root", className, {
+              "PrismanePopoverPanel-root-open": open,
+            })}
             data-testid="prismane-popover-panel"
             ref={ref}
             {...props}

--- a/src/components/Portal/Portal.tsx
+++ b/src/components/Portal/Portal.tsx
@@ -7,7 +7,7 @@ import Box, { BoxProps } from "@components/Box";
 // Types
 import { PrismaneProps } from "@types";
 // Utils
-import { strip } from "@utils";
+import { cx } from "@utils";
 
 export type PortalProps = PrismaneProps<
   {
@@ -27,11 +27,9 @@ const Portal = forwardRef<HTMLDivElement, PortalProps>(
 
     const portal = (
       <Box
-        className={strip(
-          `${className ? className : ""} ${
-            disabled ? "PrismanePortal-root-disabled" : ""
-          } PrismanePortal-root`
-        )}
+        className={cx("PrismanePortal-root", className, {
+          "PrismanePortal-root-disabled": disabled,
+        })}
         data-testid="prismane-portal"
         ref={ref}
         {...props}

--- a/src/components/Progress/Progress.tsx
+++ b/src/components/Progress/Progress.tsx
@@ -13,7 +13,7 @@ import {
   PrismaneShades,
 } from "@types";
 // Utils
-import { strip, fr, dual } from "@utils";
+import { cx, fr, dual } from "@utils";
 
 export type ProgressProps = PrismaneProps<
   {
@@ -44,11 +44,9 @@ const Progress = forwardRef<HTMLDivElement, ProgressProps>(
         br="full"
         bg={(theme) => (theme.mode === "dark" ? ["base", 700] : ["base", 200])}
         grow
-        className={strip(
-          `${
-            className ? className : ""
-          } PrismaneProgress-root-${size} PrismaneProgress-root`
-        )}
+        className={cx("PrismaneProgress-root", className, {
+          [`PrismaneProgress-root-${size}`]: true,
+        })}
         data-testid="prismane-progress"
         ref={ref}
         {...props}

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -14,7 +14,7 @@ import useId from "@hooks/useId";
 // Types
 import { PrismaneFieldComponent, PrismaneWithInternal } from "@types";
 // Utils
-import { strip, variants, fr } from "@utils";
+import { cx, variants, fr } from "@utils";
 
 // Internal Components
 import RadioGroup, { RadioGroupProps } from "./RadioGroup";
@@ -86,11 +86,9 @@ const Radio = forwardRef<HTMLInputElement, RadioProps>(
               aspectRatio: "1/1",
               ...sx,
             }}
-            className={strip(
-              `${className ? className : ""} ${
-                field.value === group.value ? "PrismaneRadio-root-active" : ""
-              } PrismaneRadio-root`
-            )}
+            className={cx("PrismaneRadio-root", className, {
+              "PrismaneRadio-root-active": field.value === group.value,
+            })}
             {...rest}
           >
             <Hidden>

--- a/src/components/Radio/RadioGroup/RadioGroup.tsx
+++ b/src/components/Radio/RadioGroup/RadioGroup.tsx
@@ -10,7 +10,7 @@ import { RadioContextProvider } from "../RadioContext";
 // Types
 import { PrismaneFieldComponent } from "@types";
 // Utils
-import { strip, fr } from "@utils";
+import { cx, fr } from "@utils";
 
 export type RadioGroupProps = PrismaneFieldComponent & FlexProps;
 
@@ -26,9 +26,7 @@ const RadioGroup = forwardRef<HTMLDivElement, RadioGroupProps>(
           {label}
         </Field.Label>
         <Flex
-          className={strip(
-            `${className ? className : ""} PrismaneRadioGroup-root`
-          )}
+          className={cx("PrismaneRadioGroup-root", className)}
           align="center"
           gap={fr(4)}
           data-testid="prismane-radio-group"

--- a/src/components/SegmentedField/SegmentedField.tsx
+++ b/src/components/SegmentedField/SegmentedField.tsx
@@ -11,7 +11,7 @@ import useEmulatedFieldChange from "@hooks/useEmulatedFieldChange";
 // Types
 import { PrismaneProps } from "@types";
 // Utils
-import { variants, fr } from "@utils";
+import { cx, variants, fr } from "@utils";
 
 export type SegmentedFieldProps = PrismaneProps<
   {
@@ -24,7 +24,10 @@ export type SegmentedFieldProps = PrismaneProps<
 >;
 
 const SegmentedField = forwardRef<HTMLInputElement, SegmentedFieldProps>(
-  ({ options = [], label, error, size = "base", sx, ...props }, ref) => {
+  (
+    { options = [], label, error, size = "base", className, sx, ...props },
+    ref
+  ) => {
     const [rest, field] = useFieldProps(props);
 
     const fieldRef = useRef(ref || null);
@@ -47,7 +50,7 @@ const SegmentedField = forwardRef<HTMLInputElement, SegmentedFieldProps>(
           size={size as any}
           px={fr(0)}
           py={fr(0)}
-          className="PrismaneSegmentedField-root"
+          className={cx("PrismaneSegmentedField-root", className)}
           sx={{
             ".PrismaneField-field": {
               display: "none",

--- a/src/components/SelectField/SelectField.tsx
+++ b/src/components/SelectField/SelectField.tsx
@@ -14,7 +14,7 @@ import useOutsideClick from "@hooks/useOutsideClick";
 // Types
 import { PrismaneProps } from "@types";
 // Utils
-import { strip, variants, fr } from "@utils";
+import { cx, variants, fr } from "@utils";
 
 export type SelectFieldProps = PrismaneProps<
   {
@@ -130,9 +130,7 @@ const SelectField = forwardRef<any, SelectFieldProps>(
               </Field.Addon>
             </>
           }
-          className={strip(
-            `${className ? className : ""} PrismaneSelectField-root`
-          )}
+          className={cx("PrismaneSelectField-root", className)}
           readOnly
           data-testid="prismane-select-field"
           ref={fieldRef}

--- a/src/components/Show/Show.tsx
+++ b/src/components/Show/Show.tsx
@@ -8,7 +8,7 @@ import useMediaQuery from "@hooks/useMediaQuery/useMediaQuery";
 // Types
 import { PrismaneBreakpoints, PrismaneProps } from "@types";
 // Utils
-import { strip, dual, fr } from "@utils";
+import { cx, dual, fr } from "@utils";
 
 export type ShowProps = PrismaneProps<
   {
@@ -32,7 +32,7 @@ const Show = forwardRef<HTMLDivElement, ShowProps>(
     return (
       <Box
         dp={shown ? "flex" : "none"}
-        className={strip(`${className ? className : ""} PrismaneShow-root`)}
+        className={cx("PrismaneShow-root", className)}
         data-testid="prismane-show"
         ref={ref}
         {...props}

--- a/src/components/Skeleton/Skeleton.tsx
+++ b/src/components/Skeleton/Skeleton.tsx
@@ -4,7 +4,7 @@ import React, { forwardRef } from "react";
 // Components
 import Flex, { FlexProps } from "@components/Flex";
 // Utils
-import { strip, fr, variants } from "@utils";
+import { cx, fr, variants } from "@utils";
 
 export type SkeletonProps = {
   variant?: "circular" | "rounded" | "rectangular";
@@ -26,11 +26,9 @@ const Skeleton = forwardRef<HTMLDivElement, SkeletonProps>(
           animation: "prismane-pulse linear 2s infinite",
           ...sx,
         }}
-        className={strip(
-          `${
-            className ? className : ""
-          } PrismaneSkeleton-root-${variant} PrismaneSkeleton-root`
-        )}
+        className={cx("PrismaneSkeleton-root", className, {
+          [`PrismaneSkeleton-root-${variant}`]: true,
+        })}
         data-testid="prismane-skeleton"
         ref={ref}
         {...props}

--- a/src/components/Spinner/Spinner.tsx
+++ b/src/components/Spinner/Spinner.tsx
@@ -8,7 +8,7 @@ import Icon, { IconProps } from "@components/Icon";
 // Types
 import { PrismaneProps, PrismaneColors, PrismaneShades } from "@types";
 // Utils
-import { strip } from "@utils";
+import { cx } from "@utils";
 
 export type SpinnerProps = PrismaneProps<
   {
@@ -31,11 +31,9 @@ const Spinner = forwardRef<SVGElement, SpinnerProps>(
           animation: "prismane-spin linear 0.5s infinite",
           ...sx,
         }}
-        className={strip(
-          `${
-            className ? className : ""
-          } PrismaneSpinner-root-${size} PrismaneSpinner-root`
-        )}
+        className={cx("PrismaneSpinner-root", className, {
+          [`PrismaneSpinner-root-${size}`]: true,
+        })}
         data-testid="prismane-spinner"
         ref={ref}
         {...props}

--- a/src/components/Square/Square.tsx
+++ b/src/components/Square/Square.tsx
@@ -12,7 +12,7 @@ import {
   PrismaneProps,
 } from "@types";
 // Utils
-import { strip } from "@utils";
+import { cx } from "@utils";
 
 export type SquareProps<E extends Versatile = "div"> = PrismaneVersatile<
   E,
@@ -40,7 +40,7 @@ const Square: SquareComponent = forwardRef(
         as={Component}
         w={size}
         h={size}
-        className={strip(`${className ? className : ""} PrismaneSquare-root`)}
+        className={cx("PrismaneSquare-root", className)}
         data-testid="prismane-square"
         ref={ref}
         {...props}

--- a/src/components/Stack/Stack.tsx
+++ b/src/components/Stack/Stack.tsx
@@ -4,7 +4,7 @@ import React, { forwardRef } from "react";
 // Components
 import Flex, { FlexProps } from "@components/Flex";
 // Utils
-import { strip, fr } from "@utils";
+import { cx, fr } from "@utils";
 
 export type StackProps = FlexProps;
 
@@ -18,7 +18,7 @@ const Stack = forwardRef<HTMLDivElement, StackProps>(
         grow
         direction={direction}
         gap={gap}
-        className={strip(`${className ? className : ""} PrismaneStack-root`)}
+        className={cx("PrismaneStack-root", className)}
         data-testid="prismane-stack"
         ref={ref}
         {...props}

--- a/src/components/Switch/Switch.tsx
+++ b/src/components/Switch/Switch.tsx
@@ -10,7 +10,7 @@ import Hidden from "@components/Hidden";
 // Types
 import { PrismaneFieldComponent } from "@types";
 // Utils
-import { strip, variants, fr } from "@utils";
+import { cx, variants, fr } from "@utils";
 
 export type SwitchProps = PrismaneFieldComponent & FlexProps & TransitionProps;
 
@@ -58,11 +58,9 @@ const Switch = forwardRef<HTMLInputElement, SwitchProps>(
               cursor: "pointer",
               ...sx,
             }}
-            className={strip(
-              `${className ? className : ""} ${
-                field.value ? "PrismaneSwitch-root-active" : ""
-              } PrismaneSwitch-root`
-            )}
+            className={cx("PrismaneSwitch-root", className, {
+              "PrismaneSwitch-root-active": field.value,
+            })}
           >
             <Hidden>
               <Field

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -12,7 +12,7 @@ import {
   PrismaneBreakpoints,
 } from "@types";
 // Utils
-import { strip } from "@utils";
+import { cx } from "@utils";
 
 // Internal Components
 import TableRow, { TableRowProps } from "./TableRow";
@@ -77,7 +77,7 @@ const Table = forwardRef<HTMLTableElement, TableProps>(
             },
             ...sx,
           }}
-          className={strip(`${className ? className : ""} PrismaneTable-root`)}
+          className={cx("PrismaneTable-root", className)}
           data-testid="prismane-table"
           ref={ref}
           {...props}

--- a/src/components/Table/TableBody/TableBody.tsx
+++ b/src/components/Table/TableBody/TableBody.tsx
@@ -8,7 +8,7 @@ import { usePrismaneColor } from "@/components/PrismaneProvider";
 // Context
 import { useTableContext } from "../TableContext";
 // Utils
-import { strip } from "@utils";
+import { cx } from "@utils";
 
 export type TableBodyProps = BoxProps<"tbody">;
 
@@ -38,9 +38,7 @@ const TableBody = forwardRef<HTMLTableSectionElement, TableBodyProps>(
           },
           ...sx,
         }}
-        className={strip(
-          `${className ? className : ""} PrismaneTableBody-root`
-        )}
+        className={cx("PrismaneTableBody-root", className)}
         data-testid="prismane-table-body"
         ref={ref}
         {...props}

--- a/src/components/Table/TableCaption/TableCaption.tsx
+++ b/src/components/Table/TableCaption/TableCaption.tsx
@@ -8,7 +8,7 @@ import { useTableContext } from "../TableContext";
 // Types
 import { PrismaneProps } from "@types";
 // Utils
-import { strip, fr, variants } from "@utils";
+import { cx, fr, variants } from "@utils";
 
 export type TableCaptionProps = PrismaneProps<
   {
@@ -39,9 +39,7 @@ const TableCaption = forwardRef<HTMLTableSectionElement, TableCaptionProps>(
           lg: fr(3),
         })}
         fs={size}
-        className={strip(
-          `${className ? className : ""} PrismaneTableCaption-root`
-        )}
+        className={cx("PrismaneTableCaption-root", className)}
         sx={{
           captionSide: placement,
           ...sx,

--- a/src/components/Table/TableCell/TableCell.tsx
+++ b/src/components/Table/TableCell/TableCell.tsx
@@ -6,7 +6,7 @@ import Box, { BoxProps } from "@components/Box";
 // Context
 import { useTableContext } from "../TableContext";
 // Utils
-import { strip, fr, variants } from "@utils";
+import { cx, fr, variants } from "@utils";
 
 export type TableCellProps = BoxProps<"td">;
 
@@ -34,9 +34,7 @@ const TableCell = forwardRef<HTMLTableSectionElement, TableCellProps>(
         fs={size}
         cl={(theme) => (theme.mode === "dark" ? "white" : ["base", 900])}
         bdc={(theme) => (theme.mode === "dark" ? ["base", 700] : ["base", 300])}
-        className={strip(
-          `${className ? className : ""} PrismaneTableCell-root`
-        )}
+        className={cx("PrismaneTableCell-root", className)}
         data-testid="prismane-table-cell"
         ref={ref}
         {...props}

--- a/src/components/Table/TableFoot/TableFoot.tsx
+++ b/src/components/Table/TableFoot/TableFoot.tsx
@@ -4,7 +4,7 @@ import React, { forwardRef } from "react";
 // Components
 import Box, { BoxProps } from "@components/Box";
 // Utils
-import { strip } from "@utils";
+import { cx } from "@utils";
 
 export type TableFootProps = BoxProps<"tfoot">;
 
@@ -15,9 +15,7 @@ const TableFoot = forwardRef<HTMLTableSectionElement, TableFootProps>(
         as="tfoot"
         fw="semibold"
         cl={(theme) => (theme.mode === "dark" ? ["base", 200] : ["base", 700])}
-        className={strip(
-          `${className ? className : ""} PrismaneTableFoot-root`
-        )}
+        className={cx("PrismaneTableFoot-root", className)}
         data-testid="prismane-table-foot"
         ref={ref}
         {...props}

--- a/src/components/Table/TableHead/TableHead.tsx
+++ b/src/components/Table/TableHead/TableHead.tsx
@@ -4,7 +4,7 @@ import React, { forwardRef } from "react";
 // Components
 import Box, { BoxProps } from "@components/Box";
 // Utils
-import { strip } from "@utils";
+import { cx } from "@utils";
 
 export type TableHeadProps = BoxProps<"thead">;
 
@@ -15,9 +15,7 @@ const TableHead = forwardRef<HTMLTableSectionElement, TableHeadProps>(
         as="thead"
         fw="semibold"
         cl={(theme) => (theme.mode === "dark" ? ["base", 200] : ["base", 700])}
-        className={strip(
-          `${className ? className : ""} PrismaneTableHead-root`
-        )}
+        className={cx("PrismaneTableHead-root", className)}
         data-testid="prismane-table-head"
         ref={ref}
         {...props}

--- a/src/components/Table/TableRow/TableRow.tsx
+++ b/src/components/Table/TableRow/TableRow.tsx
@@ -4,7 +4,7 @@ import React, { forwardRef } from "react";
 // Components
 import Box, { BoxProps } from "@components/Box";
 // Utils
-import { strip } from "@utils";
+import { cx } from "@utils";
 
 export type TableRowProps = BoxProps<"tr">;
 
@@ -15,7 +15,7 @@ const TableRow = forwardRef<HTMLTableSectionElement, TableRowProps>(
         as="tr"
         w="100%"
         bdc={(theme) => (theme.mode === "dark" ? ["base", 700] : ["base", 300])}
-        className={strip(`${className ? className : ""} PrismaneTableRow-root`)}
+        className={cx("PrismaneTableRow-root", className)}
         data-testid="prismane-table-row"
         ref={ref}
         {...props}

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -8,7 +8,7 @@ import { TabsContextProvider } from "./TabsContext";
 // Types
 import { PrismaneProps, PrismaneWithInternal } from "@types";
 // Utils
-import { strip } from "@utils";
+import { cx } from "@utils";
 
 // Internal Components
 import TabsList, { TabsListProps } from "./TabsList";
@@ -43,11 +43,9 @@ const Tabs = forwardRef<HTMLDivElement, TabsProps>(
         direction="column"
         w="100%"
         h="100%"
-        className={strip(
-          `${
-            className ? className : ""
-          } PrismaneTabs-root-${variant} PrismaneTabs-root`
-        )}
+        className={cx("PrismaneTabs-root", className, {
+          [`PrismaneTabs-root-${variant}`]: true,
+        })}
         data-testid="prismane-tabs"
         ref={ref}
         {...props}

--- a/src/components/Tabs/TabsList/TabsList.tsx
+++ b/src/components/Tabs/TabsList/TabsList.tsx
@@ -6,7 +6,7 @@ import Flex, { FlexProps } from "@components/Flex";
 // Context
 import { useTabsContext } from "../TabsContext";
 // Utils
-import { strip, fr } from "@utils";
+import { cx, fr } from "@utils";
 
 export type TabsListProps = FlexProps;
 
@@ -18,7 +18,7 @@ const TabsList = forwardRef<HTMLDivElement, TabsListProps>(
       <Flex
         w="100%"
         pos="relative"
-        className={strip(`${className ? className : ""} PrismaneTabsList-root`)}
+        className={cx("PrismaneTabsList-root", className)}
         data-testid="prismane-tabs-list"
         ref={ref}
         {...props}

--- a/src/components/Tabs/TabsPanel/TabsPanel.tsx
+++ b/src/components/Tabs/TabsPanel/TabsPanel.tsx
@@ -8,7 +8,7 @@ import { useTabsContext } from "../TabsContext";
 // Types
 import { PrismaneProps } from "@types";
 // Utils
-import { strip } from "@utils";
+import { cx } from "@utils";
 
 export type TabsPanelProps = PrismaneProps<{ value: string }, FlexProps>;
 
@@ -23,9 +23,7 @@ const TabsPanel = forwardRef<HTMLDivElement, TabsPanelProps>(
             w="100%"
             h="100%"
             grow
-            className={strip(
-              `${className ? className : ""} PrismaneTabsPanel-root`
-            )}
+            className={cx("PrismaneTabsPanel-root", className)}
             data-testid="prismane-tabs-panel"
             ref={ref}
             {...props}

--- a/src/components/Tabs/TabsTab/TabsTab.tsx
+++ b/src/components/Tabs/TabsTab/TabsTab.tsx
@@ -9,7 +9,7 @@ import { useTabsContext } from "../TabsContext";
 // Types
 import { PrismaneProps } from "@types";
 // Utils
-import { strip, variants, fr } from "@utils";
+import { cx, variants, fr } from "@utils";
 
 export type TabsTabProps = PrismaneProps<
   { value: string; disabled?: boolean },
@@ -66,7 +66,7 @@ const TabsTab = forwardRef<HTMLDivElement, TabsTabProps>(
         onClick={() => {
           tabs.setValue(value);
         }}
-        className={strip(`${className ? className : ""} PrismaneTabsTab-root`)}
+        className={cx("PrismaneTabsTab-root", className)}
         data-testid="prismane-tabs-tab"
         ref={ref}
         {...props}

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -5,7 +5,7 @@ import React, { forwardRef } from "react";
 import Box, { BoxProps } from "@components/Box";
 // Types
 import { Versatile, PrismaneVersatile, PrismaneVersatileRef } from "@types";
-import { strip } from "@utils";
+import { cx } from "@utils";
 
 export type TextProps<E extends Versatile = "span"> = PrismaneVersatile<
   E,
@@ -25,7 +25,7 @@ const Text: TextComponent = forwardRef(
       <Box
         as={Component}
         cl={(theme) => (theme.mode === "dark" ? ["base", 100] : ["base", 900])}
-        className={strip(`${className ? className : ""} PrismaneText-root`)}
+        className={cx("PrismaneText-root", className)}
         data-testid="prismane-text"
         ref={ref}
         {...props}

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -6,7 +6,7 @@ import Field, { FieldProps, useFieldProps } from "@components/Field";
 // Types
 import { PrismaneProps } from "@types";
 // Utils
-import { strip, fr, variants } from "@utils";
+import { cx, fr, variants } from "@utils";
 
 export type TextFieldProps = PrismaneProps<
   {
@@ -45,9 +45,7 @@ const TextField = forwardRef<
           pr={suffix && "0"}
           pl={prefix && "0"}
           py={(prefix || suffix) && "0"}
-          className={strip(
-            `${className ? className : ""} PrismaneTextField-root`
-          )}
+          className={cx("PrismaneTextField-root", className)}
           addons={
             <>
               {prefix && (

--- a/src/components/TextareaField/TextareaField.tsx
+++ b/src/components/TextareaField/TextareaField.tsx
@@ -7,7 +7,7 @@ import Field, { FieldProps, useFieldProps } from "@components/Field";
 // Types
 import { PrismaneProps } from "@types";
 // Utils
-import { strip, fr, variants } from "@utils";
+import { cx, fr, variants } from "@utils";
 
 export type TextareaFieldProps = PrismaneProps<
   { resize?: CSS.Properties["resize"] },
@@ -63,9 +63,7 @@ const TextareaField = forwardRef<
           },
           ...sx,
         }}
-        className={strip(
-          `${className ? className : ""} PrismaneTextareaField-root`
-        )}
+        className={cx("PrismaneTextareaField-root", className)}
         data-testid="prismane-textarea-field"
         ref={ref}
         {...field}

--- a/src/components/Toaster/Toast/Toast.tsx
+++ b/src/components/Toaster/Toast/Toast.tsx
@@ -11,7 +11,7 @@ import { useToasterContext } from "../ToasterContext";
 // Types
 import { PrismaneProps } from "@types";
 // Utils
-import { strip } from "@utils";
+import { cx } from "@utils";
 
 export type ToastProps = PrismaneProps<
   {
@@ -60,7 +60,7 @@ const Toast = forwardRef<HTMLDivElement, ToastProps>(
         duration={duration}
         timing={timing}
         animated={shown}
-        className={strip(`${className ? className : ""} PrismaneToast-root`)}
+        className={cx("PrismaneToast-root", className)}
         data-testid="prismane-toast"
         ref={ref}
         {...props}

--- a/src/components/Toaster/Toaster.tsx
+++ b/src/components/Toaster/Toaster.tsx
@@ -9,7 +9,7 @@ import { ToasterContextProvider } from "./ToasterContext";
 // Types
 import { PrismaneProps } from "@types";
 // Utils
-import { strip, fr, variants } from "@utils";
+import { cx, fr, variants } from "@utils";
 
 // Internal Components
 import Toast from "./Toast";
@@ -56,11 +56,9 @@ const Toaster = forwardRef<HTMLDivElement, ToasterProps>(
               "top-left": fr(4),
             })}
             gap={fr(2)}
-            className={strip(
-              `${
-                className ? className : ""
-              } PrismaneToaster-root-${position} PrismaneToaster-root`
-            )}
+            className={cx("PrismaneToaster-root", className, {
+              [`PrismaneToaster-root-${position}`]: true,
+            })}
             data-testid="prismane-toaster"
             ref={ref}
             {...props}

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -17,7 +17,7 @@ import {
   PrismaneProps,
 } from "@types";
 // Utils
-import { strip, variants, fr } from "@utils";
+import { cx, variants, fr } from "@utils";
 
 export type TooltipProps = PrismaneProps<
   {
@@ -134,7 +134,7 @@ const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
               whiteSpace: "nowrap",
               ...sx,
             }}
-            className={strip(
+            className={cx(
               `${
                 className ? className : ""
               } PrismaneTooltip-root-${color} PrismaneTooltip-root-${position} PrismaneTooltip-root-${size} PrismaneTooltip-root`

--- a/src/components/Transition/Transition.tsx
+++ b/src/components/Transition/Transition.tsx
@@ -12,7 +12,7 @@ import {
   PrismaneProps,
 } from "@types";
 // Utils
-import { strip } from "@utils";
+import { cx } from "@utils";
 
 export type TransitionProps<E extends Versatile = "div"> = PrismaneVersatile<
   E,
@@ -64,9 +64,7 @@ const Transition: TransitionComponent = forwardRef(
     return (
       <Box
         as={Component}
-        className={strip(
-          `${className ? className : ""} PrismaneTransition-root`
-        )}
+        className={cx("PrismaneTransition-root", className)}
         sx={{
           transitionProperty: property,
           transitionDuration: `${duration}ms`,

--- a/src/utils/cx.ts
+++ b/src/utils/cx.ts
@@ -1,0 +1,5 @@
+import classNames from "classnames";
+
+export const cx = (...args: classNames.ArgumentArray) => {
+  return classNames(...args);
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -4,5 +4,5 @@ export * from "./merge";
 export * from "./object";
 export * from "./parse";
 export * from "./split";
-export * from "./strip";
+export * from "./cx";
 export * from "./variants";

--- a/src/utils/strip.ts
+++ b/src/utils/strip.ts
@@ -1,3 +1,0 @@
-export const strip = (s: string) => {
-  return s.replace(/\s+/g, " ").trim();
-};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2271,6 +2271,7 @@ __metadata:
     "@types/react-dom": ^18.2.4
     "@vitejs/plugin-react": ^4.0.0
     chromatic: ^6.20.0
+    classnames: ^2.5.1
     commitizen: ^4.3.0
     cross-env: ^7.0.3
     csstype: ^3.1.3
@@ -5483,6 +5484,13 @@ __metadata:
   version: 3.8.0
   resolution: "ci-info@npm:3.8.0"
   checksum: d0a4d3160497cae54294974a7246202244fff031b0a6ea20dd57b10ec510aa17399c41a1b0982142c105f3255aff2173e5c0dd7302ee1b2f28ba3debda375098
+  languageName: node
+  linkType: hard
+
+"classnames@npm:^2.5.1":
+  version: 2.5.1
+  resolution: "classnames@npm:2.5.1"
+  checksum: da424a8a6f3a96a2e87d01a432ba19315503294ac7e025f9fece656db6b6a0f7b5003bb1fbb51cbb0d9624d964f1b9bb35a51c73af9b2434c7b292c42231c1e5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This merge adds the `classnames` library to the `cx` util and reactors all components to use it properly.